### PR TITLE
Ed 185/feat/snapshot locking

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -15,6 +15,7 @@
         ]},
         {cache_update_interval, 5000}, % milliseconds
         {cache_update_pull_limit, 10}, % event batch size
+        {cache_cleanup_interval, 5000}, % milliseconds
         {max_cache_size, #{
             elements => 20,
             memory => 52428800 % 50Mb

--- a/config/sys.config
+++ b/config/sys.config
@@ -15,7 +15,6 @@
         ]},
         {cache_update_interval, 5000}, % milliseconds
         {cache_update_pull_limit, 10}, % event batch size
-        {cache_cleanup_interval, 5000}, % milliseconds
         {max_cache_size, #{
             elements => 20,
             memory => 52428800 % 50Mb

--- a/src/dmt_client.erl
+++ b/src/dmt_client.erl
@@ -9,14 +9,19 @@
 %% API
 -export([get_snapshot/1]).
 -export([get_snapshot/2]).
+-export([get/1]).
 -export([get/2]).
 -export([get/3]).
+-export([get_versioned/1]).
 -export([get_versioned/2]).
 -export([get_versioned/3]).
+-export([get_by_type/1]).
 -export([get_by_type/2]).
 -export([get_by_type/3]).
+-export([filter/1]).
 -export([filter/2]).
 -export([filter/3]).
+-export([fold/2]).
 -export([fold/3]).
 -export([fold/4]).
 -export([commit/2]).
@@ -53,6 +58,7 @@
 
 -type ref() :: dmsl_domain_config_thrift:'Reference'().
 -type version() :: dmsl_domain_config_thrift:'Version'().
+-type ref_arg() :: ref() | version() | head.
 -type limit() :: dmsl_domain_config_thrift:'Limit'().
 -type snapshot() :: dmsl_domain_config_thrift:'Snapshot'().
 -type commit() :: dmsl_domain_config_thrift:'Commit'().
@@ -68,11 +74,11 @@
 
 %%% API
 
--spec get_snapshot(ref()) -> snapshot() | no_return().
+-spec get_snapshot(ref_arg()) -> snapshot() | no_return().
 get_snapshot(Reference) ->
     get_snapshot(Reference, undefined).
 
--spec get_snapshot(ref(), transport_opts()) -> snapshot() | no_return().
+-spec get_snapshot(ref_arg(), transport_opts()) -> snapshot() | no_return().
 get_snapshot(Reference, Opts) ->
     Version = ref_to_version(Reference),
     case dmt_client_cache:get_snapshot(Version, Opts) of
@@ -82,38 +88,54 @@ get_snapshot(Reference, Opts) ->
             erlang:error(Error)
     end.
 
--spec get(ref(), object_ref()) -> domain_object() | no_return().
+-spec get(object_ref()) -> domain_object() | no_return().
+get(ObjectReference) ->
+    get(head, ObjectReference).
+
+-spec get(ref_arg(), object_ref()) -> domain_object() | no_return().
 get(Reference, ObjectReference) ->
     get(Reference, ObjectReference, undefined).
 
--spec get(ref(), object_ref(), transport_opts()) -> domain_object() | no_return().
+-spec get(ref_arg(), object_ref(), transport_opts()) -> domain_object() | no_return().
 get(Reference, ObjectReference, Opts) ->
     Version = ref_to_version(Reference),
-    unwrap(dmt_client_cache:get_object(Version, ObjectReference, Opts)).
+    unwrap(dmt_client_cache:get(Version, ObjectReference, Opts)).
 
--spec get_versioned(ref(), object_ref()) -> versioned_object() | no_return().
+-spec get_versioned(object_ref()) -> versioned_object() | no_return().
+get_versioned(ObjectReference) ->
+    get_versioned(head, ObjectReference).
+
+-spec get_versioned(ref_arg(), object_ref()) -> versioned_object() | no_return().
 get_versioned(Reference, ObjectReference) ->
     get_versioned(Reference, ObjectReference, undefined).
 
--spec get_versioned(ref(), object_ref(), transport_opts()) -> versioned_object() | no_return().
+-spec get_versioned(ref_arg(), object_ref(), transport_opts()) -> versioned_object() | no_return().
 get_versioned(Reference, ObjectReference, Opts) ->
     Version = ref_to_version(Reference),
     #'VersionedObject'{version = Version, object = get(Reference, ObjectReference, Opts)}.
 
--spec get_by_type(ref(), object_type()) -> [domain_object()] | no_return().
+-spec get_by_type(object_type()) -> [domain_object()] | no_return().
+get_by_type(ObjectType) ->
+    get_by_type(head, ObjectType).
+
+-spec get_by_type(ref_arg(), object_type()) -> [domain_object()] | no_return().
 get_by_type(Reference, ObjectType) ->
     get_by_type(Reference, ObjectType, undefined).
 
--spec get_by_type(ref(), object_type(), transport_opts()) -> [domain_object()] | no_return().
+-spec get_by_type(ref_arg(), object_type(), transport_opts()) -> [domain_object()] | no_return().
 get_by_type(Reference, ObjectType, Opts) ->
     Version = ref_to_version(Reference),
     unwrap(dmt_client_cache:get_by_type(Version, ObjectType, Opts)).
 
--spec filter(ref(), object_filter()) -> [{object_type(), domain_object()}] | no_return().
+-spec filter(object_filter()) -> [{object_type(), domain_object()}] | no_return().
+filter(Filter) ->
+    filter(head, Filter).
+
+-spec filter(ref_arg(), object_filter()) -> [{object_type(), domain_object()}] | no_return().
 filter(Reference, Filter) ->
     filter(Reference, Filter, undefined).
 
--spec filter(ref(), object_filter(), transport_opts()) -> [{object_type(), domain_object()}] | no_return().
+-spec filter(ref_arg(), object_filter(), transport_opts()) -> [{object_type(), domain_object()}] | no_return().
 filter(Reference, Filter, Opts) ->
     Folder = fun(Type, Object, Acc) ->
         case Filter(Type, Object) of
@@ -123,11 +145,15 @@ filter(Reference, Filter, Opts) ->
     end,
     fold(Reference, Folder, [], Opts).
 
--spec fold(ref(), object_folder(Acc), Acc) -> Acc | no_return().
+-spec fold(object_folder(Acc), Acc) -> Acc | no_return().
+fold(Folder, Acc) ->
+    fold(head, Folder, Acc).
+
+-spec fold(ref_arg(), object_folder(Acc), Acc) -> Acc | no_return().
 fold(Reference, Folder, Acc) ->
     fold(Reference, Folder, Acc, undefined).
 
--spec fold(ref(), object_folder(Acc), Acc, transport_opts()) -> Acc | no_return().
+-spec fold(ref_arg(), object_folder(Acc), Acc, transport_opts()) -> Acc | no_return().
 fold(Reference, Folder, Acc, Opts) ->
     Version = ref_to_version(Reference),
     unwrap(dmt_client_cache:fold(Version, Folder, Acc, Opts)).
@@ -189,6 +215,10 @@ unwrap({error, {woody_error, _} = Error}) -> erlang:error(Error);
 unwrap({error, _}) -> erlang:throw(#'ObjectNotFound'{}).
 
 -spec ref_to_version(ref()) -> version().
+ref_to_version(Version) when is_integer(Version) ->
+    Version;
+ref_to_version(head) ->
+    dmt_client_cache:get_last_version();
 ref_to_version({version, Version}) ->
     Version;
 ref_to_version({head, #'Head'{}}) ->

--- a/src/dmt_client.erl
+++ b/src/dmt_client.erl
@@ -82,7 +82,7 @@ checkout(Reference) ->
 -spec checkout(version(), transport_opts()) -> snapshot() | no_return().
 checkout(Reference, Opts) ->
     Version = ref_to_version(Reference),
-    case dmt_client_cache:checkout(Version, Opts) of
+    case dmt_client_cache:get(Version, Opts) of
         {ok, Snapshot} ->
             Snapshot;
         {error, Error} ->
@@ -100,7 +100,7 @@ checkout_object(Reference, ObjectReference) ->
 -spec checkout_object(version(), object_ref(), transport_opts()) -> domain_object() | no_return().
 checkout_object(Reference, ObjectReference, Opts) ->
     Version = ref_to_version(Reference),
-    unwrap(dmt_client_cache:checkout_object(Version, ObjectReference, Opts)).
+    unwrap(dmt_client_cache:get_object(Version, ObjectReference, Opts)).
 
 -spec checkout_versioned_object(object_ref()) -> versioned_object() | no_return().
 checkout_versioned_object(ObjectReference) ->
@@ -126,7 +126,7 @@ checkout_objects_by_type(Reference, ObjectType) ->
 -spec checkout_objects_by_type(version(), object_type(), transport_opts()) -> [domain_object()] | no_return().
 checkout_objects_by_type(Reference, ObjectType, Opts) ->
     Version = ref_to_version(Reference),
-    unwrap(dmt_client_cache:checkout_objects_by_type(Version, ObjectType, Opts)).
+    unwrap(dmt_client_cache:get_objects_by_type(Version, ObjectType, Opts)).
 
 -spec checkout_filter_objects(object_filter()) -> [{object_type(), domain_object()}] | no_return().
 checkout_filter_objects(Filter) ->
@@ -158,7 +158,7 @@ checkout_fold_objects(Reference, Folder, Acc) ->
 -spec checkout_fold_objects(version(), object_folder(Acc), Acc, transport_opts()) -> Acc | no_return().
 checkout_fold_objects(Reference, Folder, Acc, Opts) ->
     Version = ref_to_version(Reference),
-    unwrap(dmt_client_cache:checkout_fold_objects(Version, Folder, Acc, Opts)).
+    unwrap(dmt_client_cache:fold_objects(Version, Folder, Acc, Opts)).
 
 -spec commit(version(), commit()) -> version() | no_return().
 commit(Version, Commit) ->

--- a/src/dmt_client.erl
+++ b/src/dmt_client.erl
@@ -7,23 +7,23 @@
 -behaviour(application).
 
 %% API
--export([get_snapshot/1]).
--export([get_snapshot/2]).
--export([get/1]).
--export([get/2]).
--export([get/3]).
--export([get_versioned/1]).
--export([get_versioned/2]).
--export([get_versioned/3]).
--export([get_by_type/1]).
--export([get_by_type/2]).
--export([get_by_type/3]).
--export([filter/1]).
--export([filter/2]).
--export([filter/3]).
--export([fold/2]).
--export([fold/3]).
--export([fold/4]).
+-export([checkout/1]).
+-export([checkout/2]).
+-export([checkout_object/1]).
+-export([checkout_object/2]).
+-export([checkout_object/3]).
+-export([checkout_versioned_object/1]).
+-export([checkout_versioned_object/2]).
+-export([checkout_versioned_object/3]).
+-export([checkout_objects_by_type/1]).
+-export([checkout_objects_by_type/2]).
+-export([checkout_objects_by_type/3]).
+-export([checkout_filter_objects/1]).
+-export([checkout_filter_objects/2]).
+-export([checkout_filter_objects/3]).
+-export([checkout_fold_objects/2]).
+-export([checkout_fold_objects/3]).
+-export([checkout_fold_objects/4]).
 -export([commit/2]).
 -export([commit/3]).
 -export([get_last_version/0]).
@@ -75,89 +75,90 @@
 
 %%% API
 
--spec get_snapshot(version()) -> snapshot() | no_return().
-get_snapshot(Reference) ->
-    get_snapshot(Reference, undefined).
+-spec checkout(version()) -> snapshot() | no_return().
+checkout(Reference) ->
+    checkout(Reference, undefined).
 
--spec get_snapshot(version(), transport_opts()) -> snapshot() | no_return().
-get_snapshot(Reference, Opts) ->
+-spec checkout(version(), transport_opts()) -> snapshot() | no_return().
+checkout(Reference, Opts) ->
     Version = ref_to_version(Reference),
-    case dmt_client_cache:get_snapshot(Version, Opts) of
+    case dmt_client_cache:checkout(Version, Opts) of
         {ok, Snapshot} ->
             Snapshot;
         {error, Error} ->
             erlang:error(Error)
     end.
 
--spec get(object_ref()) -> domain_object() | no_return().
-get(ObjectReference) ->
-    get(latest, ObjectReference).
+-spec checkout_object(object_ref()) -> domain_object() | no_return().
+checkout_object(ObjectReference) ->
+    checkout_object(latest, ObjectReference).
 
--spec get(version(), object_ref()) -> domain_object() | no_return().
-get(Reference, ObjectReference) ->
-    get(Reference, ObjectReference, undefined).
+-spec checkout_object(version(), object_ref()) -> domain_object() | no_return().
+checkout_object(Reference, ObjectReference) ->
+    checkout_object(Reference, ObjectReference, undefined).
 
--spec get(version(), object_ref(), transport_opts()) -> domain_object() | no_return().
-get(Reference, ObjectReference, Opts) ->
+-spec checkout_object(version(), object_ref(), transport_opts()) -> domain_object() | no_return().
+checkout_object(Reference, ObjectReference, Opts) ->
     Version = ref_to_version(Reference),
-    unwrap(dmt_client_cache:get(Version, ObjectReference, Opts)).
+    unwrap(dmt_client_cache:checkout_object(Version, ObjectReference, Opts)).
 
--spec get_versioned(object_ref()) -> versioned_object() | no_return().
-get_versioned(ObjectReference) ->
-    get_versioned(latest, ObjectReference).
+-spec checkout_versioned_object(object_ref()) -> versioned_object() | no_return().
+checkout_versioned_object(ObjectReference) ->
+    checkout_versioned_object(latest, ObjectReference).
 
--spec get_versioned(version(), object_ref()) -> versioned_object() | no_return().
-get_versioned(Reference, ObjectReference) ->
-    get_versioned(Reference, ObjectReference, undefined).
+-spec checkout_versioned_object(version(), object_ref()) -> versioned_object() | no_return().
+checkout_versioned_object(Reference, ObjectReference) ->
+    checkout_versioned_object(Reference, ObjectReference, undefined).
 
--spec get_versioned(version(), object_ref(), transport_opts()) -> versioned_object() | no_return().
-get_versioned(Reference, ObjectReference, Opts) ->
+-spec checkout_versioned_object(version(), object_ref(), transport_opts()) -> versioned_object() | no_return().
+checkout_versioned_object(Reference, ObjectReference, Opts) ->
     Version = ref_to_version(Reference),
-    #'VersionedObject'{version = Version, object = get(Reference, ObjectReference, Opts)}.
+    #'VersionedObject'{version = Version, object = checkout_object(Reference, ObjectReference, Opts)}.
 
--spec get_by_type(object_type()) -> [domain_object()] | no_return().
-get_by_type(ObjectType) ->
-    get_by_type(latest, ObjectType).
+-spec checkout_objects_by_type(object_type()) -> [domain_object()] | no_return().
+checkout_objects_by_type(ObjectType) ->
+    checkout_objects_by_type(latest, ObjectType).
 
--spec get_by_type(version(), object_type()) -> [domain_object()] | no_return().
-get_by_type(Reference, ObjectType) ->
-    get_by_type(Reference, ObjectType, undefined).
+-spec checkout_objects_by_type(version(), object_type()) -> [domain_object()] | no_return().
+checkout_objects_by_type(Reference, ObjectType) ->
+    checkout_objects_by_type(Reference, ObjectType, undefined).
 
--spec get_by_type(version(), object_type(), transport_opts()) -> [domain_object()] | no_return().
-get_by_type(Reference, ObjectType, Opts) ->
+-spec checkout_objects_by_type(version(), object_type(), transport_opts()) -> [domain_object()] | no_return().
+checkout_objects_by_type(Reference, ObjectType, Opts) ->
     Version = ref_to_version(Reference),
-    unwrap(dmt_client_cache:get_by_type(Version, ObjectType, Opts)).
+    unwrap(dmt_client_cache:checkout_objects_by_type(Version, ObjectType, Opts)).
 
--spec filter(object_filter()) -> [{object_type(), domain_object()}] | no_return().
-filter(Filter) ->
-    filter(latest, Filter).
+-spec checkout_filter_objects(object_filter()) -> [{object_type(), domain_object()}] | no_return().
+checkout_filter_objects(Filter) ->
+    checkout_filter_objects(latest, Filter).
 
--spec filter(version(), object_filter()) -> [{object_type(), domain_object()}] | no_return().
-filter(Reference, Filter) ->
-    filter(Reference, Filter, undefined).
+-spec checkout_filter_objects(version(), object_filter()) -> [{object_type(), domain_object()}] | no_return().
+checkout_filter_objects(Reference, Filter) ->
+    checkout_filter_objects(Reference, Filter, undefined).
 
--spec filter(version(), object_filter(), transport_opts()) -> [{object_type(), domain_object()}] | no_return().
-filter(Reference, Filter, Opts) ->
+-spec checkout_filter_objects(version(), object_filter(), transport_opts()) ->
+    [{object_type(), domain_object()}] | no_return().
+checkout_filter_objects(Reference, Filter, Opts) ->
     Folder = fun(Type, Object, Acc) ->
         case Filter(Type, Object) of
             true -> [{Type, Object} | Acc];
             false -> Acc
         end
     end,
-    fold(Reference, Folder, [], Opts).
+    checkout_fold_objects(Reference, Folder, [], Opts).
 
--spec fold(object_folder(Acc), Acc) -> Acc | no_return().
-fold(Folder, Acc) ->
-    fold(latest, Folder, Acc).
+-spec checkout_fold_objects(object_folder(Acc), Acc) -> Acc | no_return().
+checkout_fold_objects(Folder, Acc) ->
+    checkout_fold_objects(latest, Folder, Acc).
 
--spec fold(version(), object_folder(Acc), Acc) -> Acc | no_return().
-fold(Reference, Folder, Acc) ->
-    fold(Reference, Folder, Acc, undefined).
+-spec checkout_fold_objects(version(), object_folder(Acc), Acc) -> Acc | no_return().
+checkout_fold_objects(Reference, Folder, Acc) ->
+    checkout_fold_objects(Reference, Folder, Acc, undefined).
 
--spec fold(version(), object_folder(Acc), Acc, transport_opts()) -> Acc | no_return().
-fold(Reference, Folder, Acc, Opts) ->
+-spec checkout_fold_objects(version(), object_folder(Acc), Acc, transport_opts()) -> Acc | no_return().
+checkout_fold_objects(Reference, Folder, Acc, Opts) ->
     Version = ref_to_version(Reference),
-    unwrap(dmt_client_cache:fold(Version, Folder, Acc, Opts)).
+    unwrap(dmt_client_cache:checkout_fold_objects(Version, Folder, Acc, Opts)).
 
 -spec commit(version(), commit()) -> version() | no_return().
 commit(Version, Commit) ->

--- a/src/dmt_client_api.erl
+++ b/src/dmt_client_api.erl
@@ -7,8 +7,7 @@
 -export([pull_range/3]).
 -export([checkout_object/3]).
 
--spec commit(dmt_client:version(), dmt_client:commit(), dmt_client:transport_opts()) ->
-    dmt_client:version() | no_return().
+-spec commit(dmt_client:vsn(), dmt_client:commit(), dmt_client:transport_opts()) -> dmt_client:vsn() | no_return().
 commit(Version, Commit, Opts) ->
     call('Repository', 'Commit', {Version, Commit}, Opts).
 
@@ -16,7 +15,7 @@ commit(Version, Commit, Opts) ->
 checkout(Reference, Opts) ->
     call('Repository', 'Checkout', {Reference}, Opts).
 
--spec pull_range(dmt_client:version(), dmt_client:limit(), dmt_client:transport_opts()) ->
+-spec pull_range(dmt_client:vsn(), dmt_client:limit(), dmt_client:transport_opts()) ->
     dmt_client:history() | no_return().
 pull_range(After, Limit, Opts) ->
     call('Repository', 'PullRange', {After, Limit}, Opts).

--- a/src/dmt_client_backend.erl
+++ b/src/dmt_client_backend.erl
@@ -7,21 +7,19 @@
 
 %%% Behaviour callbacks
 
--callback commit(dmt_client:version(), dmt_client:commit(), dmt_client:transport_opts()) ->
-    dmt_client:version() | no_return().
+-callback commit(dmt_client:vsn(), dmt_client:commit(), dmt_client:transport_opts()) -> dmt_client:vsn() | no_return().
 
 -callback checkout(dmt_client:ref(), dmt_client:transport_opts()) -> dmt_client:snapshot() | no_return().
 
 -callback checkout_object(dmt_client:ref(), dmt_client:object_ref(), dmt_client:transport_opts()) ->
     dmsl_domain_thrift:'DomainObject'() | no_return().
 
--callback pull_range(dmt_client:version(), dmt_client:limit(), dmt_client:transport_opts()) ->
+-callback pull_range(dmt_client:vsn(), dmt_client:limit(), dmt_client:transport_opts()) ->
     dmt_client:history() | no_return().
 
 %%% API
 
--spec commit(dmt_client:version(), dmt_client:commit(), dmt_client:transport_opts()) ->
-    dmt_client:version() | no_return().
+-spec commit(dmt_client:vsn(), dmt_client:commit(), dmt_client:transport_opts()) -> dmt_client:vsn() | no_return().
 commit(Version, Commit, Opts) ->
     call(commit, [Version, Commit, Opts]).
 
@@ -34,7 +32,7 @@ checkout(Reference, Opts) ->
 checkout_object(Reference, ObjectReference, Opts) ->
     call(checkout_object, [Reference, ObjectReference, Opts]).
 
--spec pull_range(dmt_client:version(), dmt_client:limit(), dmt_client:transport_opts()) ->
+-spec pull_range(dmt_client:vsn(), dmt_client:limit(), dmt_client:transport_opts()) ->
     dmt_client:history() | no_return().
 pull_range(After, Limit, Opts) ->
     call(pull_range, [After, Limit, Opts]).

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -603,15 +603,8 @@ test_get_object_by_type() ->
     Version = 6,
     Cat1 = fixture(category),
     Cat2 = fixture(category_2),
-    Cur = fixture(currency),
 
-    Domain = dmt_insert_many(
-        [
-            {category, Cat1},
-            {category, Cat2},
-            {currency, Cur}
-        ]
-    ),
+    Domain = domain_with_all_fixtures(),
 
     ok = put_snapshot(#'Snapshot'{version = Version, domain = Domain}),
 
@@ -623,13 +616,7 @@ test_fold() ->
     set_cache_limits(1),
     Version = 7,
 
-    Domain = dmt_insert_many(
-        [
-            {category, fixture(category)},
-            {category, fixture(category_2)},
-            {currency, fixture(currency)}
-        ]
-    ),
+    Domain = domain_with_all_fixtures(),
 
     ok = put_snapshot(#'Snapshot'{version = Version, domain = Domain}),
 
@@ -651,6 +638,15 @@ test_fold() ->
     ),
 
     [1, 2] = ordsets:to_list(OrdSet).
+
+domain_with_all_fixtures() ->
+    dmt_insert_many(
+        [
+            {category, fixture(category)},
+            {category, fixture(category_2)},
+            {currency, fixture(currency)}
+        ]
+    ).
 
 dmt_insert_many(Objects) ->
     dmt_insert_many(Objects, dmt_domain:new()).

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -109,22 +109,34 @@ start_link() ->
 -spec checkout(dmt_client:vsn(), dmt_client:transport_opts()) ->
     {ok, dmt_client:snapshot()} | {error, version_not_found | woody_error()}.
 checkout(Version, Opts) ->
-    with_version(Version, Opts, fun() -> do_checkout(Version) end).
+    with_version(Version, Opts, fun
+        ({ok, _Version}) -> do_checkout(Version);
+        ({error, _} = Error) -> Error
+    end).
 
 -spec checkout_object(dmt_client:vsn(), dmt_client:object_ref(), dmt_client:transport_opts()) ->
     {ok, dmt_client:domain_object()} | {error, version_not_found | object_not_found | woody_error()}.
 checkout_object(Version, ObjectRef, Opts) ->
-    with_version(Version, Opts, fun() -> do_checkout_object(Version, ObjectRef) end).
+    with_version(Version, Opts, fun
+        ({ok, _Version}) -> do_checkout_object(Version, ObjectRef);
+        ({error, _} = Error) -> Error
+    end).
 
 -spec checkout_objects_by_type(dmt_client:vsn(), dmt_client:object_type(), dmt_client:transport_opts()) ->
     {ok, [dmt_client:domain_object()]} | {error, version_not_found | woody_error()}.
 checkout_objects_by_type(Version, ObjectType, Opts) ->
-    with_version(Version, Opts, fun() -> do_checkout_objects_by_type(Version, ObjectType) end).
+    with_version(Version, Opts, fun
+        ({ok, _Version}) -> do_checkout_objects_by_type(Version, ObjectType);
+        ({error, _} = Error) -> Error
+    end).
 
 -spec checkout_fold_objects(dmt_client:vsn(), dmt_client:object_folder(Acc), Acc, dmt_client:transport_opts()) ->
     {ok, Acc} | {error, version_not_found | woody_error()}.
 checkout_fold_objects(Version, Folder, Acc, Opts) ->
-    with_version(Version, Opts, fun() -> do_checkout_fold_objects(Version, Folder, Acc) end).
+    with_version(Version, Opts, fun
+        ({ok, _Version}) -> do_checkout_fold_objects(Version, Folder, Acc);
+        ({error, _} = Error) -> Error
+    end).
 
 -spec get_last_version() -> dmt_client:vsn() | no_return().
 get_last_version() ->
@@ -243,10 +255,10 @@ with_version(Version, Opts, Fun) ->
         end,
     case Result of
         {ok, Version} ->
-            Fun();
+            Fun({ok, Version});
         {fetched, Version} ->
             try
-                Fun()
+                Fun({ok, Version})
             catch
                 Class:Reason:Stacktrace ->
                     erlang:raise(Class, Reason, Stacktrace)

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -161,7 +161,7 @@ update() ->
 
 %%% gen_server callbacks
 
--spec init(_) -> {ok, state(), 0}.
+-spec init(_) -> {ok, state()}.
 init(_) ->
     ok = create_tables(),
     self() ! {update_timer, timeout},
@@ -375,7 +375,7 @@ fetch_by_reference(Reference, From, Timestamp, Opts, #state{waiters = Waiters} =
 -spec maybe_fetch(
     dmt_client:ref(),
     from() | undefined,
-    timestamp(),
+    timestamp() | undefined,
     dispatch_fun(),
     waiters(),
     dmt_client:transport_opts()
@@ -499,7 +499,8 @@ restart_cleanup_timer(State = #state{cleanup_timer = TimerRef}) ->
 cancel_timer(undefined) ->
     ok;
 cancel_timer(TimerRef) ->
-    erlang:cancel_timer(TimerRef).
+    _ = erlang:cancel_timer(TimerRef),
+    ok.
 
 unlock_version(Version, TS) ->
     ets:delete_object(?USERS_TABLE, #user{vsn = Version, requested_at = TS, pid = self()}).

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -154,7 +154,6 @@ get_last_version() ->
 update() ->
     case call(update) of
         {fetched, Version} ->
-            cast({unlock, Version, self()}),
             {ok, Version};
         AsIs ->
             AsIs

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -109,34 +109,22 @@ start_link() ->
 -spec get_snapshot(dmt_client:vsn(), dmt_client:transport_opts()) ->
     {ok, dmt_client:snapshot()} | {error, version_not_found | woody_error()}.
 get_snapshot(Version, Opts) ->
-    with_version(Version, Opts, fun
-        ({ok, _Version}) -> do_get_snapshot(Version);
-        ({error, _} = Error) -> Error
-    end).
+    with_version(Version, Opts, fun() -> do_get_snapshot(Version) end).
 
 -spec get(dmt_client:vsn(), dmt_client:object_ref(), dmt_client:transport_opts()) ->
     {ok, dmt_client:domain_object()} | {error, version_not_found | object_not_found | woody_error()}.
 get(Version, ObjectRef, Opts) ->
-    with_version(Version, Opts, fun
-        ({ok, _Version}) -> do_get(Version, ObjectRef);
-        ({error, _} = Error) -> Error
-    end).
+    with_version(Version, Opts, fun() -> do_get(Version, ObjectRef) end).
 
 -spec get_by_type(dmt_client:vsn(), dmt_client:object_type(), dmt_client:transport_opts()) ->
     {ok, [dmt_client:domain_object()]} | {error, version_not_found | woody_error()}.
 get_by_type(Version, ObjectType, Opts) ->
-    with_version(Version, Opts, fun
-        ({ok, _Version}) -> do_get_by_type(Version, ObjectType);
-        ({error, _} = Error) -> Error
-    end).
+    with_version(Version, Opts, fun() -> do_get_by_type(Version, ObjectType) end).
 
 -spec fold(dmt_client:vsn(), dmt_client:object_folder(Acc), Acc, dmt_client:transport_opts()) ->
     {ok, Acc} | {error, version_not_found | woody_error()}.
 fold(Version, Folder, Acc, Opts) ->
-    with_version(Version, Opts, fun
-        ({ok, _Version}) -> do_fold(Version, Folder, Acc);
-        ({error, _} = Error) -> Error
-    end).
+    with_version(Version, Opts, fun() -> do_fold(Version, Folder, Acc) end).
 
 -spec get_last_version() -> dmt_client:vsn() | no_return().
 get_last_version() ->
@@ -255,10 +243,10 @@ with_version(Version, Opts, Fun) ->
         end,
     case Result of
         {ok, Version} ->
-            Fun({ok, Version});
+            Fun();
         {fetched, Version} ->
             try
-                Fun({ok, Version})
+                Fun()
             catch
                 Class:Reason:Stacktrace ->
                     erlang:raise(Class, Reason, Stacktrace)

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -109,34 +109,22 @@ start_link() ->
 -spec get(dmt_client:vsn(), dmt_client:transport_opts()) ->
     {ok, dmt_client:snapshot()} | {error, version_not_found | woody_error()}.
 get(Version, Opts) ->
-    with_version(Version, Opts, fun
-        ({ok, _Version}) -> do_get(Version);
-        ({error, _} = Error) -> Error
-    end).
+    with_version(Version, Opts, fun() -> do_get(Version) end).
 
 -spec get_object(dmt_client:vsn(), dmt_client:object_ref(), dmt_client:transport_opts()) ->
     {ok, dmt_client:domain_object()} | {error, version_not_found | object_not_found | woody_error()}.
 get_object(Version, ObjectRef, Opts) ->
-    with_version(Version, Opts, fun
-        ({ok, _Version}) -> do_get_object(Version, ObjectRef);
-        ({error, _} = Error) -> Error
-    end).
+    with_version(Version, Opts, fun() -> do_get_object(Version, ObjectRef) end).
 
 -spec get_objects_by_type(dmt_client:vsn(), dmt_client:object_type(), dmt_client:transport_opts()) ->
     {ok, [dmt_client:domain_object()]} | {error, version_not_found | woody_error()}.
 get_objects_by_type(Version, ObjectType, Opts) ->
-    with_version(Version, Opts, fun
-        ({ok, _Version}) -> do_get_objects_by_type(Version, ObjectType);
-        ({error, _} = Error) -> Error
-    end).
+    with_version(Version, Opts, fun() -> do_get_objects_by_type(Version, ObjectType) end).
 
 -spec fold_objects(dmt_client:vsn(), dmt_client:object_folder(Acc), Acc, dmt_client:transport_opts()) ->
     {ok, Acc} | {error, version_not_found | woody_error()}.
 fold_objects(Version, Folder, Acc, Opts) ->
-    with_version(Version, Opts, fun
-        ({ok, _Version}) -> do_fold_objects(Version, Folder, Acc);
-        ({error, _} = Error) -> Error
-    end).
+    with_version(Version, Opts, fun() -> do_fold_objects(Version, Folder, Acc) end).
 
 -spec get_last_version() -> dmt_client:vsn() | no_return().
 get_last_version() ->
@@ -255,10 +243,10 @@ with_version(Version, Opts, Fun) ->
         end,
     case Result of
         {ok, Version} ->
-            Fun({ok, Version});
+            Fun();
         {fetched, Version} ->
             try
-                Fun({ok, Version})
+                Fun()
             catch
                 Class:Reason:Stacktrace ->
                     erlang:raise(Class, Reason, Stacktrace)

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -484,7 +484,7 @@ restart_update_timer(State = #state{update_timer = TimerRef}) ->
 -spec restart_cleanup_timer(state()) -> state().
 restart_cleanup_timer(State = #state{cleanup_timer = TimerRef}) ->
     cancel_timer(TimerRef),
-    Interval = genlib_app:env(dmt_client, cache_update_interval, ?DEFAULT_CLEANUP_INTERVAL),
+    Interval = genlib_app:env(dmt_client, cache_cleanup_interval, ?DEFAULT_CLEANUP_INTERVAL),
     State#state{cleanup_timer = erlang:send_after(Interval, self(), {cleanup_timer, timeout})}.
 
 cancel_timer(undefined) ->

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -24,7 +24,8 @@
 
 -define(TABLE, ?MODULE).
 -define(SERVER, ?MODULE).
--define(DEFAULT_INTERVAL, 5000).
+-define(DEFAULT_UPDATE_INTERVAL, 5000).
+-define(DEFAULT_CLEANUP_INTERVAL, 5000).
 -define(DEFAULT_LIMIT, 10).
 -define(DEFAULT_CALL_TIMEOUT, 10000).
 
@@ -72,9 +73,15 @@
     dmt_client:ref() => [{from() | undefined, dispatch_fun()}]
 }.
 
+-type users() :: #{
+    dmt_client:vsn() => [pid()]
+}.
+
 -record(state, {
-    timer = undefined :: undefined | reference(),
-    waiters = #{} :: waiters()
+    update_timer = undefined :: undefined | reference(),
+    cleanup_timer = undefined :: undefined | reference(),
+    waiters = #{} :: waiters(),
+    users = #{} :: users()
 }).
 
 -type state() :: #state{}.
@@ -88,36 +95,34 @@ start_link() ->
 -spec get_snapshot(dmt_client:vsn(), dmt_client:transport_opts()) ->
     {ok, dmt_client:snapshot()} | {error, version_not_found | woody_error()}.
 get_snapshot(Version, Opts) ->
-    case ensure_version(Version, Opts) of
-        {ok, Version} ->
-            do_get_snapshot(Version);
-        {error, _} = Error ->
-            Error
-    end.
+    with_version(Version, Opts, fun
+        ({ok, _Version}) -> do_get_snapshot(Version);
+        ({error, _} = Error) -> Error
+    end).
 
 -spec get(dmt_client:vsn(), dmt_client:object_ref(), dmt_client:transport_opts()) ->
     {ok, dmt_client:domain_object()} | {error, version_not_found | object_not_found | woody_error()}.
 get(Version, ObjectRef, Opts) ->
-    case ensure_version(Version, Opts) of
-        {ok, Version} -> do_get(Version, ObjectRef);
-        {error, _} = Error -> Error
-    end.
+    with_version(Version, Opts, fun
+        ({ok, _Version}) -> do_get(Version, ObjectRef);
+        ({error, _} = Error) -> Error
+    end).
 
 -spec get_by_type(dmt_client:vsn(), dmt_client:object_type(), dmt_client:transport_opts()) ->
     {ok, [dmt_client:domain_object()]} | {error, version_not_found | woody_error()}.
 get_by_type(Version, ObjectType, Opts) ->
-    case ensure_version(Version, Opts) of
-        {ok, Version} -> do_get_by_type(Version, ObjectType);
-        {error, _} = Error -> Error
-    end.
+    with_version(Version, Opts, fun
+        ({ok, _Version}) -> do_get_by_type(Version, ObjectType);
+        ({error, _} = Error) -> Error
+    end).
 
 -spec fold(dmt_client:vsn(), dmt_client:object_folder(Acc), Acc, dmt_client:transport_opts()) ->
     {ok, Acc} | {error, version_not_found | woody_error()}.
 fold(Version, Folder, Acc, Opts) ->
-    case ensure_version(Version, Opts) of
-        {ok, Version} -> do_fold(Version, Folder, Acc);
-        {error, _} = Error -> Error
-    end.
+    with_version(Version, Opts, fun
+        ({ok, _Version}) -> do_fold(Version, Folder, Acc);
+        ({error, _} = Error) -> Error
+    end).
 
 -spec get_last_version() -> dmt_client:vsn() | no_return().
 get_last_version() ->
@@ -135,14 +140,21 @@ get_last_version() ->
 
 -spec update() -> {ok, dmt_client:vsn()} | {error, woody_error()}.
 update() ->
-    call(update).
+    case call(update) of
+        {fetched, Version} ->
+            cast({unlock, Version, self()}),
+            {ok, Version};
+        AsIs ->
+            AsIs
+    end.
 
 %%% gen_server callbacks
 
 -spec init(_) -> {ok, state(), 0}.
 init(_) ->
     ok = create_tables(),
-    {ok, #state{}, 0}.
+    self() ! {update_timer, timeout},
+    {ok, restart_cleanup_timer(#state{})}.
 
 -spec handle_call(term(), {pid(), term()}, state()) -> {reply, term(), state()}.
 handle_call({fetch_version, Version, Opts}, From, State) ->
@@ -158,18 +170,41 @@ handle_call(_Msg, _From, State) ->
     {noreply, State}.
 
 -spec handle_cast(term(), state()) -> {noreply, state()}.
-handle_cast({dispatch, Reference, Result}, #state{waiters = Waiters} = State) ->
-    _ = [DispatchFun(From, Result) || {From, DispatchFun} <- maps:get(Reference, Waiters, [])],
-    {noreply, State#state{waiters = maps:remove(Reference, Waiters)}};
-handle_cast(cleanup, State) ->
-    cleanup(),
-    {noreply, State};
+handle_cast({dispatch, Reference, Result}, #state{waiters = Waiters, users = Users} = State) ->
+    VersionWaiters = maps:get(Reference, Waiters, []),
+    _ = [DispatchFun(From, Result) || {From, DispatchFun} <- VersionWaiters],
+    NewUsers =
+        case Result of
+            {ok, Version} ->
+                add_users(Version, VersionWaiters, Users);
+            _ ->
+                Users
+        end,
+    {noreply, State#state{waiters = maps:remove(Reference, Waiters), users = NewUsers}};
+handle_cast({unlock, Version, Pid}, State = #state{users = Users}) ->
+    NewUsers =
+        case Users of
+            #{Version := VerUserSet} ->
+                NewVerUserSet = sets:del_element(Pid, VerUserSet),
+                case sets:size(NewVerUserSet) of
+                    0 -> maps:remove(Version, Users);
+                    _ -> Users#{Version => NewVerUserSet}
+                end;
+            _ ->
+                Users
+        end,
+    {noreply, State#state{users = NewUsers}};
+handle_cast(update, State) ->
+    {noreply, update(undefined, State)};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
 -spec handle_info(term(), state()) -> {noreply, state()}.
-handle_info(timeout, State) ->
+handle_info({update_timer, timeout}, State) ->
     {noreply, update(undefined, State)};
+handle_info({cleanup_timer, timeout}, State) ->
+    cleanup(State),
+    {noreply, State};
 handle_info(_Msg, State) ->
     {noreply, State}.
 
@@ -182,6 +217,15 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 %%% Internal functions
+
+add_users(Version, Waiters, Users) ->
+    InitUsers =
+        case maps:find(Version, Users) of
+            error -> sets:new();
+            {ok, IUs} -> IUs
+        end,
+    Pids = [Pid || {{Pid, _}, _} <- Waiters],
+    Users#{Version => sets:union(InitUsers, sets:from_list(Pids))}.
 
 -spec create_tables() -> ok.
 create_tables() ->
@@ -206,10 +250,27 @@ call(Msg, Timeout) ->
 cast(Msg) ->
     gen_server:cast(?SERVER, Msg).
 
-ensure_version(Version, Opts) ->
-    case ets:member(?TABLE, Version) of
-        true -> {ok, Version};
-        false -> call({fetch_version, Version, Opts})
+with_version(Version, Opts, Fun) ->
+    Result =
+        case ets:member(?TABLE, Version) of
+            true -> {ok, Version};
+            false -> call({fetch_version, Version, Opts})
+        end,
+    case Result of
+        {ok, Version} ->
+            Fun({ok, Version});
+        {fetched, Version} ->
+            try
+                Fun({ok, Version})
+            catch
+                Class:Reason:Stacktrace ->
+                    erlang:raise(Class, Reason, Stacktrace)
+            after
+                %% Notify server that we finished working on ets copy for further possible cleanup
+                cast({unlock, Version, self()})
+            end;
+        Error ->
+            Error
     end.
 
 -spec do_get_snapshot(dmt_client:vsn()) -> {ok, dmt_client:snapshot()} | {error, version_not_found}.
@@ -280,7 +341,6 @@ put_snapshot(#'Snapshot'{version = Version, domain = Domain}) ->
                 last_access = timestamp()
             },
             true = ets:insert(?TABLE, Snap),
-            cast(cleanup),
             ok
     end.
 
@@ -309,7 +369,7 @@ get_all_snaps() ->
     ets:tab2list(?TABLE).
 
 update(From, State) ->
-    restart_timer(fetch_by_reference({head, #'Head'{}}, From, undefined, State)).
+    restart_update_timer(fetch_by_reference({head, #'Head'{}}, From, undefined, State)).
 
 fetch_by_reference(Reference, From, Opts, #state{waiters = Waiters} = State) ->
     DispatchFun = fun dispatch_reply/2,
@@ -375,7 +435,7 @@ do_fetch(Reference, Opts) ->
 dispatch_reply(undefined, _Result) ->
     ok;
 dispatch_reply(From, {ok, Version}) ->
-    gen_server:reply(From, {ok, Version});
+    gen_server:reply(From, {fetched, Version});
 dispatch_reply(From, Error) ->
     gen_server:reply(From, Error).
 
@@ -415,38 +475,46 @@ do_get_last_version() ->
             {ok, Version}
     end.
 
--spec restart_timer(state()) -> state().
-restart_timer(State = #state{timer = undefined}) ->
-    start_timer(State);
-restart_timer(State = #state{timer = TimerRef}) ->
-    _ = erlang:cancel_timer(TimerRef),
-    start_timer(State#state{timer = undefined}).
+-spec restart_update_timer(state()) -> state().
+restart_update_timer(State = #state{update_timer = TimerRef}) ->
+    cancel_timer(TimerRef),
+    Interval = genlib_app:env(dmt_client, cache_update_interval, ?DEFAULT_UPDATE_INTERVAL),
+    State#state{update_timer = erlang:send_after(Interval, self(), {update_timer, timeout})}.
 
--spec start_timer(state()) -> state().
-start_timer(State = #state{timer = undefined}) ->
-    Interval = genlib_app:env(dmt_client, cache_update_interval, ?DEFAULT_INTERVAL),
-    State#state{timer = erlang:send_after(Interval, self(), timeout)}.
+-spec restart_cleanup_timer(state()) -> state().
+restart_cleanup_timer(State = #state{cleanup_timer = TimerRef}) ->
+    cancel_timer(TimerRef),
+    Interval = genlib_app:env(dmt_client, cache_update_interval, ?DEFAULT_CLEANUP_INTERVAL),
+    State#state{cleanup_timer = erlang:send_after(Interval, self(), {cleanup_timer, timeout})}.
 
--spec cleanup() -> ok.
-cleanup() ->
+cancel_timer(undefined) ->
+    ok;
+cancel_timer(TimerRef) ->
+    erlang:cancel_timer(TimerRef).
+
+-spec cleanup(state()) -> ok.
+cleanup(#state{users = Users}) ->
     Snaps = get_all_snaps(),
     Sorted = lists:keysort(#snap.last_access, Snaps),
-    {ok, HeadVersion} = do_get_last_version(),
-    cleanup(Sorted, HeadVersion).
+    case do_get_last_version() of
+        {ok, HeadVersion} -> cleanup(Sorted, HeadVersion, Users);
+        _ -> ok
+    end.
 
--spec cleanup([snap()], dmt_client:vsn()) -> ok.
-cleanup([], _HeadVersion) ->
+-spec cleanup([snap()], dmt_client:vsn(), users()) -> ok.
+cleanup([], _HeadVersion, _Users) ->
     ok;
-cleanup(Snaps, HeadVersion) ->
+cleanup(Snaps, HeadVersion, Users) ->
     {Elements, Memory} = get_cache_size(),
     CacheLimits = genlib_app:env(dmt_client, max_cache_size),
     MaxElements = genlib_map:get(elements, CacheLimits, 20),
     % 50Mb by default
     MaxMemory = genlib_map:get(memory, CacheLimits, 52428800),
+
     case Elements > MaxElements orelse (Elements > 1 andalso Memory > MaxMemory) of
         true ->
-            Tail = remove_earliest(Snaps, HeadVersion),
-            cleanup(Tail, HeadVersion);
+            Tail = remove_earliest(Snaps, HeadVersion, Users),
+            cleanup(Tail, HeadVersion, Users);
         false ->
             ok
     end.
@@ -473,12 +541,17 @@ ets_memory(TID) ->
     Info = ets:info(TID),
     proplists:get_value(memory, Info).
 
--spec remove_earliest([snap()], dmt_client:vsn()) -> [snap()].
-remove_earliest([#snap{vsn = HeadVersion} | Tail], HeadVersion) ->
+-spec remove_earliest([snap()], dmt_client:vsn(), users()) -> [snap()].
+remove_earliest([#snap{vsn = HeadVersion} | Tail], HeadVersion, _) ->
     Tail;
-remove_earliest([Snap | Tail], _HeadVersion) ->
-    remove_snap(Snap),
-    Tail.
+remove_earliest([Snap = #snap{vsn = Version} | Tail], HeadVersion, Users) ->
+    case maps:is_key(Version, Users) of
+        true ->
+            [Snap | remove_earliest(Tail, HeadVersion, Users)];
+        false ->
+            remove_snap(Snap),
+            Tail
+    end.
 
 -spec remove_snap(snap()) -> ok.
 remove_snap(#snap{tid = TID, vsn = Version}) ->
@@ -534,7 +607,7 @@ test_cleanup() ->
     ok = put_snapshot(#'Snapshot'{version = 3, domain = dmt_domain:new()}),
     ok = put_snapshot(#'Snapshot'{version = 2, domain = dmt_domain:new()}),
     ok = put_snapshot(#'Snapshot'{version = 1, domain = dmt_domain:new()}),
-    cleanup(),
+    cleanup(#state{}),
     [
         #snap{vsn = 1, _ = _},
         #snap{vsn = 4, _ = _}
@@ -550,7 +623,7 @@ test_last_access() ->
     Ref = {category, #'domain_CategoryRef'{id = 1}},
     {error, object_not_found} = get(3, Ref, undefined),
     ok = put_snapshot(#'Snapshot'{version = 1, domain = dmt_domain:new()}),
-    cleanup(),
+    cleanup(#state{}),
     [
         #snap{vsn = 1, _ = _},
         #snap{vsn = 3, _ = _},

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -24,7 +24,8 @@
 
 -define(TABLE, ?MODULE).
 -define(SERVER, ?MODULE).
--define(DEFAULT_INTERVAL, 5000).
+-define(DEFAULT_UPDATE_INTERVAL, 5000).
+-define(DEFAULT_CLEANUP_INTERVAL, 5000).
 -define(DEFAULT_LIMIT, 10).
 -define(DEFAULT_CALL_TIMEOUT, 10000).
 
@@ -74,9 +75,15 @@
     dmt_client:ref() => [{from() | undefined, dispatch_fun()}]
 }.
 
+-type users() :: #{
+    dmt_client:vsn() => [pid()]
+}.
+
 -record(state, {
-    timer = undefined :: undefined | reference(),
-    waiters = #{} :: waiters()
+    update_timer = undefined :: undefined | reference(),
+    cleanup_timer = undefined :: undefined | reference(),
+    waiters = #{} :: waiters(),
+    users = #{} :: users()
 }).
 
 -type state() :: #state{}.
@@ -90,36 +97,34 @@ start_link() ->
 -spec get(dmt_client:vsn(), dmt_client:transport_opts()) ->
     {ok, dmt_client:snapshot()} | {error, version_not_found | woody_error()}.
 get(Version, Opts) ->
-    case ensure_version(Version, Opts) of
-        {ok, Version} ->
-            do_get(Version);
-        {error, _} = Error ->
-            Error
-    end.
+    with_version(Version, Opts, fun
+        ({ok, _Version}) -> do_get(Version);
+        ({error, _} = Error) -> Error
+    end).
 
 -spec get_object(dmt_client:vsn(), dmt_client:object_ref(), dmt_client:transport_opts()) ->
     {ok, dmt_client:domain_object()} | {error, version_not_found | object_not_found | woody_error()}.
 get_object(Version, ObjectRef, Opts) ->
-    case ensure_version(Version, Opts) of
-        {ok, Version} -> do_get_object(Version, ObjectRef);
-        {error, _} = Error -> Error
-    end.
+    with_version(Version, Opts, fun
+        ({ok, _Version}) -> do_get_object(Version, ObjectRef);
+        ({error, _} = Error) -> Error
+    end).
 
 -spec get_objects_by_type(dmt_client:vsn(), dmt_client:object_type(), dmt_client:transport_opts()) ->
     {ok, [dmt_client:domain_object()]} | {error, version_not_found | woody_error()}.
 get_objects_by_type(Version, ObjectType, Opts) ->
-    case ensure_version(Version, Opts) of
-        {ok, Version} -> do_get_objects_by_type(Version, ObjectType);
-        {error, _} = Error -> Error
-    end.
+    with_version(Version, Opts, fun
+        ({ok, _Version}) -> do_get_objects_by_type(Version, ObjectType);
+        ({error, _} = Error) -> Error
+    end).
 
 -spec fold_objects(dmt_client:vsn(), dmt_client:object_folder(Acc), Acc, dmt_client:transport_opts()) ->
     {ok, Acc} | {error, version_not_found | woody_error()}.
 fold_objects(Version, Folder, Acc, Opts) ->
-    case ensure_version(Version, Opts) of
-        {ok, Version} -> do_fold_objects(Version, Folder, Acc);
-        {error, _} = Error -> Error
-    end.
+    with_version(Version, Opts, fun
+        ({ok, _Version}) -> do_fold_objects(Version, Folder, Acc);
+        ({error, _} = Error) -> Error
+    end).
 
 -spec get_last_version() -> dmt_client:vsn() | no_return().
 get_last_version() ->
@@ -137,14 +142,21 @@ get_last_version() ->
 
 -spec update() -> {ok, dmt_client:vsn()} | {error, woody_error()}.
 update() ->
-    call(update).
+    case call(update) of
+        {fetched, Version} ->
+            cast({unlock, Version, self()}),
+            {ok, Version};
+        AsIs ->
+            AsIs
+    end.
 
 %%% gen_server callbacks
 
 -spec init(_) -> {ok, state(), 0}.
 init(_) ->
     ok = create_tables(),
-    {ok, #state{}, 0}.
+    self() ! {update_timer, timeout},
+    {ok, restart_cleanup_timer(#state{})}.
 
 -spec handle_call(term(), {pid(), term()}, state()) -> {reply, term(), state()}.
 handle_call({fetch_version, Version, Opts}, From, State) ->
@@ -160,18 +172,41 @@ handle_call(_Msg, _From, State) ->
     {noreply, State}.
 
 -spec handle_cast(term(), state()) -> {noreply, state()}.
-handle_cast({dispatch, Reference, Result}, #state{waiters = Waiters} = State) ->
-    _ = [DispatchFun(From, Result) || {From, DispatchFun} <- maps:get(Reference, Waiters, [])],
-    {noreply, State#state{waiters = maps:remove(Reference, Waiters)}};
-handle_cast(cleanup, State) ->
-    cleanup(),
-    {noreply, State};
+handle_cast({dispatch, Reference, Result}, #state{waiters = Waiters, users = Users} = State) ->
+    VersionWaiters = maps:get(Reference, Waiters, []),
+    _ = [DispatchFun(From, Result) || {From, DispatchFun} <- VersionWaiters],
+    NewUsers =
+        case Result of
+            {ok, Version} ->
+                add_users(Version, VersionWaiters, Users);
+            _ ->
+                Users
+        end,
+    {noreply, State#state{waiters = maps:remove(Reference, Waiters), users = NewUsers}};
+handle_cast({unlock, Version, Pid}, State = #state{users = Users}) ->
+    NewUsers =
+        case Users of
+            #{Version := VerUserSet} ->
+                NewVerUserSet = sets:del_element(Pid, VerUserSet),
+                case sets:size(NewVerUserSet) of
+                    0 -> maps:remove(Version, Users);
+                    _ -> Users#{Version => NewVerUserSet}
+                end;
+            _ ->
+                Users
+        end,
+    {noreply, State#state{users = NewUsers}};
+handle_cast(update, State) ->
+    {noreply, update(undefined, State)};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
 -spec handle_info(term(), state()) -> {noreply, state()}.
-handle_info(timeout, State) ->
+handle_info({update_timer, timeout}, State) ->
     {noreply, update(undefined, State)};
+handle_info({cleanup_timer, timeout}, State) ->
+    cleanup(State),
+    {noreply, State};
 handle_info(_Msg, State) ->
     {noreply, State}.
 
@@ -184,6 +219,15 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 %%% Internal functions
+
+add_users(Version, Waiters, Users) ->
+    InitUsers =
+        case maps:find(Version, Users) of
+            error -> sets:new();
+            {ok, IUs} -> IUs
+        end,
+    Pids = [Pid || {{Pid, _}, _} <- Waiters],
+    Users#{Version => sets:union(InitUsers, sets:from_list(Pids))}.
 
 -spec create_tables() -> ok.
 create_tables() ->
@@ -208,10 +252,27 @@ call(Msg, Timeout) ->
 cast(Msg) ->
     gen_server:cast(?SERVER, Msg).
 
-ensure_version(Version, Opts) ->
-    case ets:member(?TABLE, Version) of
-        true -> {ok, Version};
-        false -> call({fetch_version, Version, Opts})
+with_version(Version, Opts, Fun) ->
+    Result =
+        case ets:member(?TABLE, Version) of
+            true -> {ok, Version};
+            false -> call({fetch_version, Version, Opts})
+        end,
+    case Result of
+        {ok, Version} ->
+            Fun({ok, Version});
+        {fetched, Version} ->
+            try
+                Fun({ok, Version})
+            catch
+                Class:Reason:Stacktrace ->
+                    erlang:raise(Class, Reason, Stacktrace)
+            after
+                %% Notify server that we finished working on ets copy for further possible cleanup
+                cast({unlock, Version, self()})
+            end;
+        Error ->
+            Error
     end.
 
 -spec do_get(dmt_client:vsn()) -> {ok, dmt_client:snapshot()} | {error, version_not_found}.
@@ -282,7 +343,6 @@ put_snapshot(#'Snapshot'{version = Version, domain = Domain}) ->
                 last_access = timestamp()
             },
             true = ets:insert(?TABLE, Snap),
-            cast(cleanup),
             ok
     end.
 
@@ -311,7 +371,7 @@ get_all_snaps() ->
     ets:tab2list(?TABLE).
 
 update(From, State) ->
-    restart_timer(fetch_by_reference({head, #'Head'{}}, From, undefined, State)).
+    restart_update_timer(fetch_by_reference({head, #'Head'{}}, From, undefined, State)).
 
 fetch_by_reference(Reference, From, Opts, #state{waiters = Waiters} = State) ->
     DispatchFun = fun dispatch_reply/2,
@@ -384,7 +444,7 @@ update_head(Head, PullLimit, Opts) ->
 dispatch_reply(undefined, _Result) ->
     ok;
 dispatch_reply(From, {ok, Version}) ->
-    gen_server:reply(From, {ok, Version});
+    gen_server:reply(From, {fetched, Version});
 dispatch_reply(From, Error) ->
     gen_server:reply(From, Error).
 
@@ -424,38 +484,46 @@ do_get_last_version() ->
             {ok, Version}
     end.
 
--spec restart_timer(state()) -> state().
-restart_timer(State = #state{timer = undefined}) ->
-    start_timer(State);
-restart_timer(State = #state{timer = TimerRef}) ->
-    _ = erlang:cancel_timer(TimerRef),
-    start_timer(State#state{timer = undefined}).
+-spec restart_update_timer(state()) -> state().
+restart_update_timer(State = #state{update_timer = TimerRef}) ->
+    cancel_timer(TimerRef),
+    Interval = genlib_app:env(dmt_client, cache_update_interval, ?DEFAULT_UPDATE_INTERVAL),
+    State#state{update_timer = erlang:send_after(Interval, self(), {update_timer, timeout})}.
 
--spec start_timer(state()) -> state().
-start_timer(State = #state{timer = undefined}) ->
-    Interval = genlib_app:env(dmt_client, cache_update_interval, ?DEFAULT_INTERVAL),
-    State#state{timer = erlang:send_after(Interval, self(), timeout)}.
+-spec restart_cleanup_timer(state()) -> state().
+restart_cleanup_timer(State = #state{cleanup_timer = TimerRef}) ->
+    cancel_timer(TimerRef),
+    Interval = genlib_app:env(dmt_client, cache_update_interval, ?DEFAULT_CLEANUP_INTERVAL),
+    State#state{cleanup_timer = erlang:send_after(Interval, self(), {cleanup_timer, timeout})}.
 
--spec cleanup() -> ok.
-cleanup() ->
+cancel_timer(undefined) ->
+    ok;
+cancel_timer(TimerRef) ->
+    erlang:cancel_timer(TimerRef).
+
+-spec cleanup(state()) -> ok.
+cleanup(#state{users = Users}) ->
     Snaps = get_all_snaps(),
     Sorted = lists:keysort(#snap.last_access, Snaps),
-    {ok, HeadVersion} = do_get_last_version(),
-    cleanup(Sorted, HeadVersion).
+    case do_get_last_version() of
+        {ok, HeadVersion} -> cleanup(Sorted, HeadVersion, Users);
+        _ -> ok
+    end.
 
--spec cleanup([snap()], dmt_client:vsn()) -> ok.
-cleanup([], _HeadVersion) ->
+-spec cleanup([snap()], dmt_client:vsn(), users()) -> ok.
+cleanup([], _HeadVersion, _Users) ->
     ok;
-cleanup(Snaps, HeadVersion) ->
+cleanup(Snaps, HeadVersion, Users) ->
     {Elements, Memory} = get_cache_size(),
     CacheLimits = genlib_app:env(dmt_client, max_cache_size),
     MaxElements = genlib_map:get(elements, CacheLimits, 20),
     % 50Mb by default
     MaxMemory = genlib_map:get(memory, CacheLimits, 52428800),
+
     case Elements > MaxElements orelse (Elements > 1 andalso Memory > MaxMemory) of
         true ->
-            Tail = remove_earliest(Snaps, HeadVersion),
-            cleanup(Tail, HeadVersion);
+            Tail = remove_earliest(Snaps, HeadVersion, Users),
+            cleanup(Tail, HeadVersion, Users);
         false ->
             ok
     end.
@@ -482,12 +550,17 @@ ets_memory(TID) ->
     Info = ets:info(TID),
     proplists:get_value(memory, Info).
 
--spec remove_earliest([snap()], dmt_client:vsn()) -> [snap()].
-remove_earliest([#snap{vsn = HeadVersion} | Tail], HeadVersion) ->
+-spec remove_earliest([snap()], dmt_client:vsn(), users()) -> [snap()].
+remove_earliest([#snap{vsn = HeadVersion} | Tail], HeadVersion, _) ->
     Tail;
-remove_earliest([Snap | Tail], _HeadVersion) ->
-    remove_snap(Snap),
-    Tail.
+remove_earliest([Snap = #snap{vsn = Version} | Tail], HeadVersion, Users) ->
+    case maps:is_key(Version, Users) of
+        true ->
+            [Snap | remove_earliest(Tail, HeadVersion, Users)];
+        false ->
+            remove_snap(Snap),
+            Tail
+    end.
 
 -spec remove_snap(snap()) -> ok.
 remove_snap(#snap{tid = TID, vsn = Version}) ->
@@ -543,7 +616,7 @@ test_cleanup() ->
     ok = put_snapshot(#'Snapshot'{version = 3, domain = dmt_domain:new()}),
     ok = put_snapshot(#'Snapshot'{version = 2, domain = dmt_domain:new()}),
     ok = put_snapshot(#'Snapshot'{version = 1, domain = dmt_domain:new()}),
-    cleanup(),
+    cleanup(#state{}),
     [
         #snap{vsn = 1, _ = _},
         #snap{vsn = 4, _ = _}
@@ -559,7 +632,7 @@ test_last_access() ->
     Ref = {category, #'domain_CategoryRef'{id = 1}},
     {error, object_not_found} = get_object(3, Ref, undefined),
     ok = put_snapshot(#'Snapshot'{version = 1, domain = dmt_domain:new()}),
-    cleanup(),
+    cleanup(#state{}),
     [
         #snap{vsn = 1, _ = _},
         #snap{vsn = 3, _ = _},

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -156,7 +156,6 @@ get_last_version() ->
 update() ->
     case call(update) of
         {fetched, Version} ->
-            cast({unlock, Version, self()}),
             {ok, Version};
         AsIs ->
             AsIs

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -512,30 +512,10 @@ unlock_version(Version, TS) ->
 cleanup() ->
     Snaps = get_all_snaps(),
     Sorted = lists:keysort(#snap.last_access, Snaps),
-    cleanup_users(Snaps),
     case do_get_last_version() of
         {ok, HeadVersion} -> cleanup(Sorted, HeadVersion);
         _ -> ok
     end.
-
-cleanup_users(Snaps) ->
-    VersionMap =
-        lists:foldl(
-            fun(#snap{vsn = Version}, Acc) -> sets:add_element(Version, Acc) end,
-            sets:new(),
-            Snaps
-        ),
-
-    ets:foldl(
-        fun(Rec = #user{vsn = Version, pid = Pid, requested_at = '_'}, _) ->
-            case sets:is_element(Version, VersionMap) andalso erlang:is_alive(Pid) of
-                true -> ok;
-                false -> ets:delete_object(?USERS_TABLE, Rec)
-            end
-        end,
-        ok,
-        ?USERS_TABLE
-    ).
 
 -spec cleanup([snap()], dmt_client:vsn()) -> ok.
 cleanup([], _HeadVersion) ->

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -530,11 +530,7 @@ cleanup(Snaps, HeadVersion) ->
     case Elements > MaxElements orelse (Elements > 1 andalso Memory > MaxMemory) of
         true ->
             Tail = remove_earliest(Snaps, HeadVersion),
-            %% It's possible that all snaps are locked by users: try later
-            case Snaps == Tail of
-                true -> ok;
-                false -> cleanup(Tail, HeadVersion)
-            end;
+            cleanup(Tail, HeadVersion);
         false ->
             ok
     end.
@@ -562,8 +558,6 @@ ets_memory(TID) ->
     proplists:get_value(memory, Info).
 
 -spec remove_earliest([snap()], dmt_client:vsn()) -> [snap()].
-remove_earliest([], _HeadVersion) ->
-    [];
 remove_earliest([#snap{vsn = HeadVersion} | Tail], HeadVersion) ->
     Tail;
 remove_earliest([Snap = #snap{vsn = Version, cached_at = StoredAt} | Tail], HeadVersion) ->

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -13,14 +13,6 @@
 -export([get_last_version/0]).
 -export([update/0]).
 
--ifdef(TEST).
-%% Test-only helpers for white-box testing
--export([get_snapshot/1]).
--export([get/2]).
--export([get_by_type/2]).
--export([fold/3]).
--endif.
-
 %% gen_server callbacks
 
 -export([init/1]).
@@ -511,25 +503,6 @@ timestamp() ->
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("damsel/include/dmsl_domain_thrift.hrl").
 
--spec get_snapshot(dmt_client:version()) -> {ok, dmt_client:snapshot()} | {error, version_not_found | woody_error()}.
-get_snapshot(Version) ->
-    get_snapshot(Version, undefined).
-
--spec get(dmt_client:version(), dmt_client:object_ref()) ->
-    {ok, dmt_client:domain_object()} | {error, version_not_found | object_not_found | woody_error()}.
-get(Version, ObjectRef) ->
-    get(Version, ObjectRef, undefined).
-
--spec get_by_type(dmt_client:version(), dmt_client:object_type()) ->
-    {ok, [dmt_client:domain_object()]} | {error, version_not_found | woody_error()}.
-get_by_type(Version, ObjectRef) ->
-    get_by_type(Version, ObjectRef, undefined).
-
--spec fold(dmt_client:version(), dmt_client:object_folder(Acc), Acc) ->
-    {ok, Acc} | {error, version_not_found | woody_error()}.
-fold(Version, Folder, Acc) ->
-    fold(Version, Folder, Acc, undefined).
-
 % dirty hack for warn_missing_spec
 -spec test() -> any().
 
@@ -576,7 +549,7 @@ test_last_access() ->
     ok = put_snapshot(#'Snapshot'{version = 3, domain = dmt_domain:new()}),
     ok = put_snapshot(#'Snapshot'{version = 2, domain = dmt_domain:new()}),
     Ref = {category, #'domain_CategoryRef'{id = 1}},
-    {error, object_not_found} = get(3, Ref),
+    {error, object_not_found} = get(3, Ref, undefined),
     ok = put_snapshot(#'Snapshot'{version = 1, domain = dmt_domain:new()}),
     [
         #snap{vsn = 1, _ = _},
@@ -634,7 +607,8 @@ test_fold() ->
             (_Type, _Obj, Acc) ->
                 Acc
         end,
-        ordsets:new()
+        ordsets:new(),
+        undefined
     ),
 
     [1, 2] = ordsets:to_list(OrdSet).

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -64,6 +64,7 @@
 -record(snap, {
     vsn :: dmt_client:vsn(),
     tid :: ets:tid(),
+    cached_at :: timestamp(),
     last_access :: timestamp()
 }).
 
@@ -76,7 +77,7 @@
 
 -record(user, {
     vsn :: dmt_client:vsn(),
-    %% request_time :: timestamp(),
+    requested_at :: timestamp(),
     pid :: pid()
 }).
 
@@ -168,12 +169,12 @@ init(_) ->
     {ok, restart_cleanup_timer(#state{})}.
 
 -spec handle_call(term(), {pid(), term()}, state()) -> {reply, term(), state()}.
-handle_call({fetch_version, Version, Opts}, From, State) ->
+handle_call({fetch_version, Version, Timestamp, Opts}, From, State) ->
     case ets:member(?TABLE, Version) of
         true ->
             {reply, {ok, Version}, State};
         false ->
-            {noreply, fetch_by_reference({version, Version}, From, Opts, State)}
+            {noreply, fetch_by_reference({version, Version}, From, Timestamp, Opts, State)}
     end;
 handle_call(update, From, State) ->
     {noreply, update(From, State)};
@@ -184,7 +185,7 @@ handle_call(_Msg, _From, State) ->
 handle_cast({dispatch, Reference, Result}, #state{waiters = Waiters} = State) ->
     VersionWaiters = maps:get(Reference, Waiters, []),
     add_users(Reference, VersionWaiters),
-    _ = [DispatchFun(From, Result) || {From, DispatchFun} <- VersionWaiters],
+    _ = [DispatchFun(From, Result) || {From, _TS, DispatchFun} <- VersionWaiters],
     {noreply, State#state{waiters = maps:remove(Reference, Waiters)}};
 handle_cast(update, State) ->
     {noreply, update(undefined, State)};
@@ -214,7 +215,10 @@ code_change(_OldVsn, State, _Extra) ->
 add_users({head, _}, _Waiters) ->
     ok;
 add_users({version, Version}, Waiters) ->
-    [ets:insert(?USERS_TABLE, #user{vsn = Version, pid = Pid}) || {{Pid, _}, _} <- Waiters],
+    [
+        ets:insert(?USERS_TABLE, #user{vsn = Version, requested_at = TS, pid = Pid})
+        || {{Pid, TS, _}, _} <- Waiters, TS /= undefined
+    ],
     ok.
 
 -spec create_tables() -> ok.
@@ -242,10 +246,11 @@ cast(Msg) ->
     gen_server:cast(?SERVER, Msg).
 
 with_version(Version, Opts, Fun) ->
+    TS = timestamp(),
     Result =
         case ets:member(?TABLE, Version) of
             true -> {ok, Version};
-            false -> call({fetch_version, Version, Opts})
+            false -> call({fetch_version, Version, TS, Opts})
         end,
     case Result of
         {ok, Version} ->
@@ -258,7 +263,7 @@ with_version(Version, Opts, Fun) ->
                     erlang:raise(Class, Reason, Stacktrace)
             after
                 %% Notify that we finished working on ets copy for further possible cleanup
-                unlock_version(Version)
+                unlock_version(Version, TS)
             end;
         Error ->
             Error
@@ -329,6 +334,7 @@ put_snapshot(#'Snapshot'{version = Version, domain = Domain}) ->
             Snap = #snap{
                 vsn = Version,
                 tid = TID,
+                cached_at = timestamp(),
                 last_access = timestamp()
             },
             true = ets:insert(?TABLE, Snap),
@@ -360,16 +366,22 @@ get_all_snaps() ->
     ets:tab2list(?TABLE).
 
 update(From, State) ->
-    restart_update_timer(fetch_by_reference({head, #'Head'{}}, From, undefined, State)).
+    restart_update_timer(fetch_by_reference({head, #'Head'{}}, From, undefined, undefined, State)).
 
-fetch_by_reference(Reference, From, Opts, #state{waiters = Waiters} = State) ->
+fetch_by_reference(Reference, From, Timestamp, Opts, #state{waiters = Waiters} = State) ->
     DispatchFun = fun dispatch_reply/2,
-    NewWaiters = maybe_fetch(Reference, From, DispatchFun, Waiters, Opts),
+    NewWaiters = maybe_fetch(Reference, From, Timestamp, DispatchFun, Waiters, Opts),
     State#state{waiters = NewWaiters}.
 
--spec maybe_fetch(dmt_client:ref(), from() | undefined, dispatch_fun(), waiters(), dmt_client:transport_opts()) ->
-    waiters().
-maybe_fetch(Reference, ReplyTo, DispatchFun, Waiters, Opts) ->
+-spec maybe_fetch(
+    dmt_client:ref(),
+    from() | undefined,
+    timestamp(),
+    dispatch_fun(),
+    waiters(),
+    dmt_client:transport_opts()
+) -> waiters().
+maybe_fetch(Reference, ReplyTo, Timestamp, DispatchFun, Waiters, Opts) ->
     Prev =
         case maps:find(Reference, Waiters) of
             error ->
@@ -378,7 +390,7 @@ maybe_fetch(Reference, ReplyTo, DispatchFun, Waiters, Opts) ->
             {ok, List} ->
                 List
         end,
-    Waiters#{Reference => [{ReplyTo, DispatchFun} | Prev]}.
+    Waiters#{Reference => [{ReplyTo, Timestamp, DispatchFun} | Prev]}.
 
 -spec schedule_fetch(dmt_client:ref(), dmt_client:transport_opts()) -> pid().
 schedule_fetch(Reference, Opts) ->
@@ -489,8 +501,8 @@ cancel_timer(undefined) ->
 cancel_timer(TimerRef) ->
     erlang:cancel_timer(TimerRef).
 
-unlock_version(Version) ->
-    ets:delete_object(?USERS_TABLE, #user{vsn = Version, pid = self()}).
+unlock_version(Version, TS) ->
+    ets:delete_object(?USERS_TABLE, #user{vsn = Version, requested_at = TS, pid = self()}).
 
 -spec cleanup() -> ok.
 cleanup() ->
@@ -544,8 +556,15 @@ ets_memory(TID) ->
 -spec remove_earliest([snap()], dmt_client:vsn()) -> [snap()].
 remove_earliest([#snap{vsn = HeadVersion} | Tail], HeadVersion) ->
     Tail;
-remove_earliest([Snap = #snap{vsn = Version} | Tail], HeadVersion) ->
-    case ets:select_count(?USERS_TABLE, [{#user{vsn = Version, pid = '_'}, [], ['$_']}]) of
+remove_earliest([Snap = #snap{vsn = Version, cached_at = StoredAt} | Tail], HeadVersion) ->
+    MatchSpec = [
+        {
+            #user{vsn = Version, pid = '_', requested_at = '$1'},
+            [{'<', '$1', StoredAt}],
+            ['$_']
+        }
+    ],
+    case ets:select_count(?USERS_TABLE, MatchSpec) of
         0 ->
             remove_snap(Snap),
             Tail;
@@ -556,7 +575,7 @@ remove_earliest([Snap = #snap{vsn = Version} | Tail], HeadVersion) ->
 -spec remove_snap(snap()) -> ok.
 remove_snap(#snap{tid = TID, vsn = Version}) ->
     true = ets:delete(?TABLE, Version),
-    _ = ets:select_delete(?USERS_TABLE, [{#user{vsn = Version, pid = '_'}, [], ['$_']}]),
+    _ = ets:select_delete(?USERS_TABLE, [{#user{vsn = Version, requested_at = '_', pid = '_'}, [], ['$_']}]),
     true = ets:delete(TID),
     ok.
 

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -42,7 +42,7 @@
 ]).
 
 -define(snapshot_table_opts, [
-    set,
+    ordered_set,
     protected,
     {read_concurrency, true},
     {write_concurrency, false},

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -511,10 +511,30 @@ unlock_version(Version, TS) ->
 cleanup() ->
     Snaps = get_all_snaps(),
     Sorted = lists:keysort(#snap.last_access, Snaps),
+    cleanup_users(Snaps),
     case do_get_last_version() of
         {ok, HeadVersion} -> cleanup(Sorted, HeadVersion);
         _ -> ok
     end.
+
+cleanup_users(Snaps) ->
+    VersionMap =
+        lists:foldl(
+            fun(#snap{vsn = Version}, Acc) -> sets:add_element(Version, Acc) end,
+            sets:new(),
+            Snaps
+        ),
+
+    ets:foldl(
+        fun(Rec = #user{vsn = Version, pid = Pid, requested_at = '_'}, _) ->
+            case sets:is_element(Version, VersionMap) andalso erlang:is_alive(Pid) of
+                true -> ok;
+                false -> ets:delete_object(?USERS_TABLE, Rec)
+            end
+        end,
+        ok,
+        ?USERS_TABLE
+    ).
 
 -spec cleanup([snap()], dmt_client:vsn()) -> ok.
 cleanup([], _HeadVersion) ->

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -64,6 +64,7 @@
 -record(snap, {
     vsn :: dmt_client:vsn(),
     tid :: ets:tid(),
+    cached_at :: timestamp(),
     last_access :: timestamp()
 }).
 
@@ -76,7 +77,7 @@
 
 -record(user, {
     vsn :: dmt_client:vsn(),
-    %% request_time :: timestamp(),
+    requested_at :: timestamp(),
     pid :: pid()
 }).
 
@@ -170,12 +171,12 @@ init(_) ->
     {ok, restart_cleanup_timer(#state{})}.
 
 -spec handle_call(term(), {pid(), term()}, state()) -> {reply, term(), state()}.
-handle_call({fetch_version, Version, Opts}, From, State) ->
+handle_call({fetch_version, Version, Timestamp, Opts}, From, State) ->
     case ets:member(?TABLE, Version) of
         true ->
             {reply, {ok, Version}, State};
         false ->
-            {noreply, fetch_by_reference({version, Version}, From, Opts, State)}
+            {noreply, fetch_by_reference({version, Version}, From, Timestamp, Opts, State)}
     end;
 handle_call(update, From, State) ->
     {noreply, update(From, State)};
@@ -186,7 +187,7 @@ handle_call(_Msg, _From, State) ->
 handle_cast({dispatch, Reference, Result}, #state{waiters = Waiters} = State) ->
     VersionWaiters = maps:get(Reference, Waiters, []),
     add_users(Reference, VersionWaiters),
-    _ = [DispatchFun(From, Result) || {From, DispatchFun} <- VersionWaiters],
+    _ = [DispatchFun(From, Result) || {From, _TS, DispatchFun} <- VersionWaiters],
     {noreply, State#state{waiters = maps:remove(Reference, Waiters)}};
 handle_cast(update, State) ->
     {noreply, update(undefined, State)};
@@ -216,7 +217,10 @@ code_change(_OldVsn, State, _Extra) ->
 add_users({head, _}, _Waiters) ->
     ok;
 add_users({version, Version}, Waiters) ->
-    [ets:insert(?USERS_TABLE, #user{vsn = Version, pid = Pid}) || {{Pid, _}, _} <- Waiters],
+    [
+        ets:insert(?USERS_TABLE, #user{vsn = Version, requested_at = TS, pid = Pid})
+        || {{Pid, TS, _}, _} <- Waiters, TS /= undefined
+    ],
     ok.
 
 -spec create_tables() -> ok.
@@ -244,10 +248,11 @@ cast(Msg) ->
     gen_server:cast(?SERVER, Msg).
 
 with_version(Version, Opts, Fun) ->
+    TS = timestamp(),
     Result =
         case ets:member(?TABLE, Version) of
             true -> {ok, Version};
-            false -> call({fetch_version, Version, Opts})
+            false -> call({fetch_version, Version, TS, Opts})
         end,
     case Result of
         {ok, Version} ->
@@ -260,7 +265,7 @@ with_version(Version, Opts, Fun) ->
                     erlang:raise(Class, Reason, Stacktrace)
             after
                 %% Notify that we finished working on ets copy for further possible cleanup
-                unlock_version(Version)
+                unlock_version(Version, TS)
             end;
         Error ->
             Error
@@ -331,6 +336,7 @@ put_snapshot(#'Snapshot'{version = Version, domain = Domain}) ->
             Snap = #snap{
                 vsn = Version,
                 tid = TID,
+                cached_at = timestamp(),
                 last_access = timestamp()
             },
             true = ets:insert(?TABLE, Snap),
@@ -362,16 +368,22 @@ get_all_snaps() ->
     ets:tab2list(?TABLE).
 
 update(From, State) ->
-    restart_update_timer(fetch_by_reference({head, #'Head'{}}, From, undefined, State)).
+    restart_update_timer(fetch_by_reference({head, #'Head'{}}, From, undefined, undefined, State)).
 
-fetch_by_reference(Reference, From, Opts, #state{waiters = Waiters} = State) ->
+fetch_by_reference(Reference, From, Timestamp, Opts, #state{waiters = Waiters} = State) ->
     DispatchFun = fun dispatch_reply/2,
-    NewWaiters = maybe_fetch(Reference, From, DispatchFun, Waiters, Opts),
+    NewWaiters = maybe_fetch(Reference, From, Timestamp, DispatchFun, Waiters, Opts),
     State#state{waiters = NewWaiters}.
 
--spec maybe_fetch(dmt_client:ref(), from() | undefined, dispatch_fun(), waiters(), dmt_client:transport_opts()) ->
-    waiters().
-maybe_fetch(Reference, ReplyTo, DispatchFun, Waiters, Opts) ->
+-spec maybe_fetch(
+    dmt_client:ref(),
+    from() | undefined,
+    timestamp(),
+    dispatch_fun(),
+    waiters(),
+    dmt_client:transport_opts()
+) -> waiters().
+maybe_fetch(Reference, ReplyTo, Timestamp, DispatchFun, Waiters, Opts) ->
     Prev =
         case maps:find(Reference, Waiters) of
             error ->
@@ -380,7 +392,7 @@ maybe_fetch(Reference, ReplyTo, DispatchFun, Waiters, Opts) ->
             {ok, List} ->
                 List
         end,
-    Waiters#{Reference => [{ReplyTo, DispatchFun} | Prev]}.
+    Waiters#{Reference => [{ReplyTo, Timestamp, DispatchFun} | Prev]}.
 
 -spec schedule_fetch(dmt_client:ref(), dmt_client:transport_opts()) -> pid().
 schedule_fetch(Reference, Opts) ->
@@ -492,8 +504,8 @@ cancel_timer(undefined) ->
 cancel_timer(TimerRef) ->
     erlang:cancel_timer(TimerRef).
 
-unlock_version(Version) ->
-    ets:delete_object(?USERS_TABLE, #user{vsn = Version, pid = self()}).
+unlock_version(Version, TS) ->
+    ets:delete_object(?USERS_TABLE, #user{vsn = Version, requested_at = TS, pid = self()}).
 
 -spec cleanup() -> ok.
 cleanup() ->
@@ -547,8 +559,15 @@ ets_memory(TID) ->
 -spec remove_earliest([snap()], dmt_client:vsn()) -> [snap()].
 remove_earliest([#snap{vsn = HeadVersion} | Tail], HeadVersion) ->
     Tail;
-remove_earliest([Snap = #snap{vsn = Version} | Tail], HeadVersion) ->
-    case ets:select_count(?USERS_TABLE, [{#user{vsn = Version, pid = '_'}, [], ['$_']}]) of
+remove_earliest([Snap = #snap{vsn = Version, cached_at = StoredAt} | Tail], HeadVersion) ->
+    MatchSpec = [
+        {
+            #user{vsn = Version, pid = '_', requested_at = '$1'},
+            [{'<', '$1', StoredAt}],
+            ['$_']
+        }
+    ],
+    case ets:select_count(?USERS_TABLE, MatchSpec) of
         0 ->
             remove_snap(Snap),
             Tail;
@@ -559,7 +578,7 @@ remove_earliest([Snap = #snap{vsn = Version} | Tail], HeadVersion) ->
 -spec remove_snap(snap()) -> ok.
 remove_snap(#snap{tid = TID, vsn = Version}) ->
     true = ets:delete(?TABLE, Version),
-    _ = ets:select_delete(?USERS_TABLE, [{#user{vsn = Version, pid = '_'}, [], ['$_']}]),
+    _ = ets:select_delete(?USERS_TABLE, [{#user{vsn = Version, requested_at = '_', pid = '_'}, [], ['$_']}]),
     true = ets:delete(TID),
     ok.
 

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -524,7 +524,7 @@ cleanup_users(Snaps) ->
 
     ets:foldl(
         fun(Rec = #user{vsn = Version, pid = Pid, requested_at = '_'}, _) ->
-            case sets:is_element(Version, VersionMap) andalso erlang:is_alive(Pid) of
+            case sets:is_element(Version, VersionMap) andalso erlang:is_process_alive(Pid) of
                 true -> ok;
                 false -> ets:delete_object(?USERS_TABLE, Rec)
             end

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -141,7 +141,7 @@ update() ->
 
 %%% gen_server callbacks
 
--spec init(_) -> {ok, state()}.
+-spec init(_) -> {ok, state(), 0}.
 init(_) ->
     ok = create_tables(),
     {ok, #state{}, 0}.

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -481,7 +481,7 @@ restart_update_timer(State = #state{update_timer = TimerRef}) ->
 -spec restart_cleanup_timer(state()) -> state().
 restart_cleanup_timer(State = #state{cleanup_timer = TimerRef}) ->
     cancel_timer(TimerRef),
-    Interval = genlib_app:env(dmt_client, cache_update_interval, ?DEFAULT_CLEANUP_INTERVAL),
+    Interval = genlib_app:env(dmt_client, cache_cleanup_interval, ?DEFAULT_CLEANUP_INTERVAL),
     State#state{cleanup_timer = erlang:send_after(Interval, self(), {cleanup_timer, timeout})}.
 
 cancel_timer(undefined) ->

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -529,7 +529,11 @@ cleanup(Snaps, HeadVersion) ->
     case Elements > MaxElements orelse (Elements > 1 andalso Memory > MaxMemory) of
         true ->
             Tail = remove_earliest(Snaps, HeadVersion),
-            cleanup(Tail, HeadVersion);
+            %% It's possible that all snaps are locked by users: try later
+            case Snaps == Tail of
+                true -> ok;
+                false -> cleanup(Tail, HeadVersion)
+            end;
         false ->
             ok
     end.
@@ -557,6 +561,8 @@ ets_memory(TID) ->
     proplists:get_value(memory, Info).
 
 -spec remove_earliest([snap()], dmt_client:vsn()) -> [snap()].
+remove_earliest([], _HeadVersion) ->
+    [];
 remove_earliest([#snap{vsn = HeadVersion} | Tail], HeadVersion) ->
     Tail;
 remove_earliest([Snap = #snap{vsn = Version, cached_at = StoredAt} | Tail], HeadVersion) ->

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -508,10 +508,30 @@ unlock_version(Version, TS) ->
 cleanup() ->
     Snaps = get_all_snaps(),
     Sorted = lists:keysort(#snap.last_access, Snaps),
+    cleanup_users(Snaps),
     case do_get_last_version() of
         {ok, HeadVersion} -> cleanup(Sorted, HeadVersion);
         _ -> ok
     end.
+
+cleanup_users(Snaps) ->
+    VersionMap =
+        lists:foldl(
+            fun(#snap{vsn = Version}, Acc) -> sets:add_element(Version, Acc) end,
+            sets:new(),
+            Snaps
+        ),
+
+    ets:foldl(
+        fun(Rec = #user{vsn = Version, pid = Pid, requested_at = '_'}, _) ->
+            case sets:is_element(Version, VersionMap) andalso erlang:is_alive(Pid) of
+                true -> ok;
+                false -> ets:delete_object(?USERS_TABLE, Rec)
+            end
+        end,
+        ok,
+        ?USERS_TABLE
+    ).
 
 -spec cleanup([snap()], dmt_client:vsn()) -> ok.
 cleanup([], _HeadVersion) ->

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -156,6 +156,7 @@ get_last_version() ->
 update() ->
     case call(update) of
         {fetched, Version} ->
+            cast({unlock, Version, self()}),
             {ok, Version};
         AsIs ->
             AsIs

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -484,7 +484,7 @@ restart_update_timer(State = #state{update_timer = TimerRef}) ->
 -spec restart_cleanup_timer(state()) -> state().
 restart_cleanup_timer(State = #state{cleanup_timer = TimerRef}) ->
     cancel_timer(TimerRef),
-    Interval = genlib_app:env(dmt_client, cache_cleanup_interval, ?DEFAULT_CLEANUP_INTERVAL),
+    Interval = genlib_app:env(dmt_client, cache_update_interval, ?DEFAULT_CLEANUP_INTERVAL),
     State#state{cleanup_timer = erlang:send_after(Interval, self(), {cleanup_timer, timeout})}.
 
 cancel_timer(undefined) ->

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -622,15 +622,12 @@ test_get_object_by_type() ->
 test_fold() ->
     set_cache_limits(1),
     Version = 7,
-    Cat1 = fixture(category),
-    Cat2 = fixture(category_2),
-    Cur = fixture(currency),
 
     Domain = dmt_insert_many(
         [
-            {category, Cat1},
-            {category, Cat2},
-            {currency, Cur}
+            {category, fixture(category)},
+            {category, fixture(category_2)},
+            {currency, fixture(currency)}
         ]
     ),
 

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -526,7 +526,7 @@ cleanup_users(Snaps) ->
 
     ets:foldl(
         fun(Rec = #user{vsn = Version, pid = Pid, requested_at = '_'}, _) ->
-            case sets:is_element(Version, VersionMap) andalso erlang:is_alive(Pid) of
+            case sets:is_element(Version, VersionMap) andalso erlang:is_process_alive(Pid) of
                 true -> ok;
                 false -> ets:delete_object(?USERS_TABLE, Rec)
             end

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -527,7 +527,7 @@ cleanup_users(Snaps) ->
 
     ets:foldl(
         fun(Rec = #user{vsn = Version, pid = Pid, requested_at = '_'}, _) ->
-            case sets:is_element(Version, VersionMap) andalso erlang:is_process_alive(Pid) of
+            case sets:is_element(Version, VersionMap) andalso erlang:is_alive(Pid) of
                 true -> ok;
                 false -> ets:delete_object(?USERS_TABLE, Rec)
             end

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -30,7 +30,6 @@
 -define(DEFAULT_CALL_TIMEOUT, 10000).
 
 -include_lib("damsel/include/dmsl_domain_config_thrift.hrl").
--include_lib("stdlib/include/ms_transform.hrl").
 
 -define(meta_table_opts, [
     named_table,
@@ -49,6 +48,17 @@
     {keypos, #object.ref}
 ]).
 
+-define(USERS_TABLE, dmt_client_cache_users).
+
+-define(users_table_opts, [
+    named_table,
+    bag,
+    public,
+    {read_concurrency, false},
+    {write_concurrency, true},
+    {keypos, #user.vsn}
+]).
+
 -type timestamp() :: integer().
 
 -record(snap, {
@@ -64,6 +74,12 @@
     obj :: dmt_client:domain_object()
 }).
 
+-record(user, {
+    vsn :: dmt_client:vsn(),
+    %% request_time :: timestamp(),
+    pid :: pid()
+}).
+
 -type woody_error() :: {woody_error, woody_error:system_error()}.
 
 -type from() :: {pid(), term()}.
@@ -73,15 +89,10 @@
     dmt_client:ref() => [{from() | undefined, dispatch_fun()}]
 }.
 
--type users() :: #{
-    dmt_client:vsn() => [pid()]
-}.
-
 -record(state, {
     update_timer = undefined :: undefined | reference(),
     cleanup_timer = undefined :: undefined | reference(),
-    waiters = #{} :: waiters(),
-    users = #{} :: users()
+    waiters = #{} :: waiters()
 }).
 
 -type state() :: #state{}.
@@ -170,30 +181,11 @@ handle_call(_Msg, _From, State) ->
     {noreply, State}.
 
 -spec handle_cast(term(), state()) -> {noreply, state()}.
-handle_cast({dispatch, Reference, Result}, #state{waiters = Waiters, users = Users} = State) ->
+handle_cast({dispatch, Reference, Result}, #state{waiters = Waiters} = State) ->
     VersionWaiters = maps:get(Reference, Waiters, []),
+    add_users(Reference, VersionWaiters),
     _ = [DispatchFun(From, Result) || {From, DispatchFun} <- VersionWaiters],
-    NewUsers =
-        case Result of
-            {ok, Version} ->
-                add_users(Version, VersionWaiters, Users);
-            _ ->
-                Users
-        end,
-    {noreply, State#state{waiters = maps:remove(Reference, Waiters), users = NewUsers}};
-handle_cast({unlock, Version, Pid}, State = #state{users = Users}) ->
-    NewUsers =
-        case Users of
-            #{Version := VerUserSet} ->
-                NewVerUserSet = sets:del_element(Pid, VerUserSet),
-                case sets:size(NewVerUserSet) of
-                    0 -> maps:remove(Version, Users);
-                    _ -> Users#{Version => NewVerUserSet}
-                end;
-            _ ->
-                Users
-        end,
-    {noreply, State#state{users = NewUsers}};
+    {noreply, State#state{waiters = maps:remove(Reference, Waiters)}};
 handle_cast(update, State) ->
     {noreply, update(undefined, State)};
 handle_cast(_Msg, State) ->
@@ -203,7 +195,7 @@ handle_cast(_Msg, State) ->
 handle_info({update_timer, timeout}, State) ->
     {noreply, update(undefined, State)};
 handle_info({cleanup_timer, timeout}, State) ->
-    cleanup(State),
+    cleanup(),
     {noreply, State};
 handle_info(_Msg, State) ->
     {noreply, State}.
@@ -218,18 +210,17 @@ code_change(_OldVsn, State, _Extra) ->
 
 %%% Internal functions
 
-add_users(Version, Waiters, Users) ->
-    InitUsers =
-        case maps:find(Version, Users) of
-            error -> sets:new();
-            {ok, IUs} -> IUs
-        end,
-    Pids = [Pid || {{Pid, _}, _} <- Waiters],
-    Users#{Version => sets:union(InitUsers, sets:from_list(Pids))}.
+%% update op: nothing to do
+add_users({head, _}, _Waiters) ->
+    ok;
+add_users({version, Version}, Waiters) ->
+    [ets:insert(?USERS_TABLE, #user{vsn = Version, pid = Pid}) || {{Pid, _}, _} <- Waiters],
+    ok.
 
 -spec create_tables() -> ok.
 create_tables() ->
     ?TABLE = ets:new(?TABLE, ?meta_table_opts),
+    ?USERS_TABLE = ets:new(?USERS_TABLE, ?users_table_opts),
     ok.
 
 -spec call(term()) -> term().
@@ -266,8 +257,8 @@ with_version(Version, Opts, Fun) ->
                 Class:Reason:Stacktrace ->
                     erlang:raise(Class, Reason, Stacktrace)
             after
-                %% Notify server that we finished working on ets copy for further possible cleanup
-                cast({unlock, Version, self()})
+                %% Notify that we finished working on ets copy for further possible cleanup
+                unlock_version(Version)
             end;
         Error ->
             Error
@@ -302,7 +293,7 @@ do_get(Version, ObjectRef) ->
 do_get_by_type(Version, ObjectType) ->
     {ok, #snap{tid = TID}} = get_snap(Version),
     MatchSpec = [
-        {{object, '_', {ObjectType, '$1'}}, [], ['$1']}
+        {#object{ref = '_', obj = {ObjectType, '$1'}}, [], ['$1']}
     ],
     try ets:select(TID, MatchSpec) of
         Result ->
@@ -498,19 +489,22 @@ cancel_timer(undefined) ->
 cancel_timer(TimerRef) ->
     erlang:cancel_timer(TimerRef).
 
--spec cleanup(state()) -> ok.
-cleanup(#state{users = Users}) ->
+unlock_version(Version) ->
+    ets:delete_object(?USERS_TABLE, #user{vsn = Version, pid = self()}).
+
+-spec cleanup() -> ok.
+cleanup() ->
     Snaps = get_all_snaps(),
     Sorted = lists:keysort(#snap.last_access, Snaps),
     case do_get_last_version() of
-        {ok, HeadVersion} -> cleanup(Sorted, HeadVersion, Users);
+        {ok, HeadVersion} -> cleanup(Sorted, HeadVersion);
         _ -> ok
     end.
 
--spec cleanup([snap()], dmt_client:vsn(), users()) -> ok.
-cleanup([], _HeadVersion, _Users) ->
+-spec cleanup([snap()], dmt_client:vsn()) -> ok.
+cleanup([], _HeadVersion) ->
     ok;
-cleanup(Snaps, HeadVersion, Users) ->
+cleanup(Snaps, HeadVersion) ->
     {Elements, Memory} = get_cache_size(),
     CacheLimits = genlib_app:env(dmt_client, max_cache_size),
     MaxElements = genlib_map:get(elements, CacheLimits, 20),
@@ -519,8 +513,8 @@ cleanup(Snaps, HeadVersion, Users) ->
 
     case Elements > MaxElements orelse (Elements > 1 andalso Memory > MaxMemory) of
         true ->
-            Tail = remove_earliest(Snaps, HeadVersion, Users),
-            cleanup(Tail, HeadVersion, Users);
+            Tail = remove_earliest(Snaps, HeadVersion),
+            cleanup(Tail, HeadVersion);
         false ->
             ok
     end.
@@ -547,21 +541,22 @@ ets_memory(TID) ->
     Info = ets:info(TID),
     proplists:get_value(memory, Info).
 
--spec remove_earliest([snap()], dmt_client:vsn(), users()) -> [snap()].
-remove_earliest([#snap{vsn = HeadVersion} | Tail], HeadVersion, _) ->
+-spec remove_earliest([snap()], dmt_client:vsn()) -> [snap()].
+remove_earliest([#snap{vsn = HeadVersion} | Tail], HeadVersion) ->
     Tail;
-remove_earliest([Snap = #snap{vsn = Version} | Tail], HeadVersion, Users) ->
-    case maps:is_key(Version, Users) of
-        true ->
-            [Snap | remove_earliest(Tail, HeadVersion, Users)];
-        false ->
+remove_earliest([Snap = #snap{vsn = Version} | Tail], HeadVersion) ->
+    case ets:select_count(?USERS_TABLE, [{#user{vsn = Version, pid = '_'}, [], ['$_']}]) of
+        0 ->
             remove_snap(Snap),
-            Tail
+            Tail;
+        _ ->
+            [Snap | remove_earliest(Tail, HeadVersion)]
     end.
 
 -spec remove_snap(snap()) -> ok.
 remove_snap(#snap{tid = TID, vsn = Version}) ->
     true = ets:delete(?TABLE, Version),
+    _ = ets:select_delete(?USERS_TABLE, [{#user{vsn = Version, pid = '_'}, [], ['$_']}]),
     true = ets:delete(TID),
     ok.
 
@@ -613,7 +608,7 @@ test_cleanup() ->
     ok = put_snapshot(#'Snapshot'{version = 3, domain = dmt_domain:new()}),
     ok = put_snapshot(#'Snapshot'{version = 2, domain = dmt_domain:new()}),
     ok = put_snapshot(#'Snapshot'{version = 1, domain = dmt_domain:new()}),
-    cleanup(#state{}),
+    cleanup(),
     [
         #snap{vsn = 1, _ = _},
         #snap{vsn = 4, _ = _}
@@ -629,7 +624,7 @@ test_last_access() ->
     Ref = {category, #'domain_CategoryRef'{id = 1}},
     {error, object_not_found} = get(3, Ref, undefined),
     ok = put_snapshot(#'Snapshot'{version = 1, domain = dmt_domain:new()}),
-    cleanup(#state{}),
+    cleanup(),
     [
         #snap{vsn = 1, _ = _},
         #snap{vsn = 3, _ = _},

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -71,15 +71,17 @@
 -type snap() :: #snap{}.
 
 -record(object, {
-    ref :: dmt_client:object_ref(),
-    obj :: dmt_client:domain_object()
+    ref :: dmt_client:object_ref() | ets_match(),
+    obj :: dmt_client:domain_object() | ets_match()
 }).
 
 -record(user, {
-    vsn :: dmt_client:vsn(),
-    requested_at :: timestamp(),
-    pid :: pid()
+    vsn :: dmt_client:vsn() | ets_match(),
+    requested_at :: timestamp() | ets_match(),
+    pid :: pid() | ets_match()
 }).
+
+-type ets_match() :: '_' | '$1' | {atom(), ets_match()}.
 
 -type woody_error() :: {woody_error, woody_error:system_error()}.
 

--- a/src/dmt_client_cache.erl
+++ b/src/dmt_client_cache.erl
@@ -435,7 +435,8 @@ do_fetch(Reference, Opts) ->
 update_head(Head, PullLimit, Opts) ->
     FreshHistory = dmt_client_backend:pull_range(Head#'Snapshot'.version, PullLimit, Opts),
     {ok, NewHead} = dmt_history:head(FreshHistory, Head),
-    case NewHead == Head of
+    %% Received history is smaller then PullLimit => reached the top of changes
+    case map_size(FreshHistory) < PullLimit of
         true -> NewHead;
         false -> update_head(NewHead, PullLimit, Opts)
     end.

--- a/test/dmt_client_cache_SUITE.erl
+++ b/test/dmt_client_cache_SUITE.erl
@@ -115,18 +115,18 @@ pull_range(_Version, _Limit, _Opts) ->
 
 -spec get_snapshot_success(config()) -> any().
 get_snapshot_success(_C) ->
-    {ok, #'Snapshot'{}} = dmt_client_cache:get_snapshot(?existing_version).
+    {ok, #'Snapshot'{}} = dmt_client_cache:get_snapshot(?existing_version, undefined).
 
 -spec snapshot_not_found(config()) -> any().
 snapshot_not_found(_C) ->
-    {error, version_not_found} = dmt_client_cache:get_snapshot(?notfound_version).
+    {error, version_not_found} = dmt_client_cache:get_snapshot(?notfound_version, undefined).
 
 -spec woody_error(config()) -> any().
 woody_error(_C) ->
-    {error, {woody_error, _}} = dmt_client_cache:get_snapshot(?unavailable_version).
+    {error, {woody_error, _}} = dmt_client_cache:get_snapshot(?unavailable_version, undefined).
 
 -spec object_not_found(config()) -> any().
 object_not_found(_C) ->
     Ref = {category, #'domain_CategoryRef'{id = 1}},
-    {error, version_not_found} = dmt_client_cache:get(?notfound_version, Ref),
-    {error, object_not_found} = dmt_client_cache:get(?existing_version, Ref).
+    {error, version_not_found} = dmt_client_cache:get(?notfound_version, Ref, undefined),
+    {error, object_not_found} = dmt_client_cache:get(?existing_version, Ref, undefined).

--- a/test/dmt_client_cache_SUITE.erl
+++ b/test/dmt_client_cache_SUITE.erl
@@ -114,18 +114,18 @@ pull_range(_Version, _Limit, _Opts) ->
 
 -spec get_snapshot_success(config()) -> any().
 get_snapshot_success(_C) ->
-    {ok, #'Snapshot'{}} = dmt_client_cache:get_snapshot(?existing_version, undefined).
+    {ok, #'Snapshot'{}} = dmt_client_cache:checkout(?existing_version, undefined).
 
 -spec snapshot_not_found(config()) -> any().
 snapshot_not_found(_C) ->
-    {error, version_not_found} = dmt_client_cache:get_snapshot(?notfound_version, undefined).
+    {error, version_not_found} = dmt_client_cache:checkout(?notfound_version, undefined).
 
 -spec woody_error(config()) -> any().
 woody_error(_C) ->
-    {error, {woody_error, _}} = dmt_client_cache:get_snapshot(?unavailable_version, undefined).
+    {error, {woody_error, _}} = dmt_client_cache:checkout(?unavailable_version, undefined).
 
 -spec object_not_found(config()) -> any().
 object_not_found(_C) ->
     Ref = {category, #'domain_CategoryRef'{id = 1}},
-    {error, version_not_found} = dmt_client_cache:get(?notfound_version, Ref, undefined),
-    {error, object_not_found} = dmt_client_cache:get(?existing_version, Ref, undefined).
+    {error, version_not_found} = dmt_client_cache:checkout_object(?notfound_version, Ref, undefined),
+    {error, object_not_found} = dmt_client_cache:checkout_object(?existing_version, Ref, undefined).

--- a/test/dmt_client_cache_SUITE.erl
+++ b/test/dmt_client_cache_SUITE.erl
@@ -83,8 +83,7 @@ end_per_suite(C) ->
 
 %%% Dummy API
 
--spec commit(dmt_client:version(), dmt_client:commit(), dmt_client:transport_opts()) ->
-    dmt_client:version() | no_return().
+-spec commit(dmt_client:vsn(), dmt_client:commit(), dmt_client:transport_opts()) -> dmt_client:vsn() | no_return().
 commit(Version, _Commit, _Opts) ->
     Version.
 
@@ -105,7 +104,7 @@ checkout({head, #'Head'{}}, _Opts) ->
 checkout_object(_Reference, _ObjectReference, _Opts) ->
     erlang:throw(#'ObjectNotFound'{}).
 
--spec pull_range(dmt_client:version(), dmt_client:limit(), dmt_client:transport_opts()) ->
+-spec pull_range(dmt_client:vsn(), dmt_client:limit(), dmt_client:transport_opts()) ->
     dmt_client:history() | no_return().
 pull_range(_Version, _Limit, _Opts) ->
     timer:sleep(5000),

--- a/test/dmt_client_cache_SUITE.erl
+++ b/test/dmt_client_cache_SUITE.erl
@@ -115,18 +115,18 @@ pull_range(_Version, _Limit, _Opts) ->
 
 -spec get_snapshot_success(config()) -> any().
 get_snapshot_success(_C) ->
-    {ok, #'Snapshot'{}} = dmt_client_cache:get(?existing_version).
+    {ok, #'Snapshot'{}} = dmt_client_cache:get_snapshot(?existing_version).
 
 -spec snapshot_not_found(config()) -> any().
 snapshot_not_found(_C) ->
-    {error, version_not_found} = dmt_client_cache:get(1).
+    {error, version_not_found} = dmt_client_cache:get_snapshot(?notfound_version).
 
 -spec woody_error(config()) -> any().
 woody_error(_C) ->
-    {error, {woody_error, _}} = dmt_client_cache:get(?unavailable_version).
+    {error, {woody_error, _}} = dmt_client_cache:get_snapshot(?unavailable_version).
 
 -spec object_not_found(config()) -> any().
 object_not_found(_C) ->
     Ref = {category, #'domain_CategoryRef'{id = 1}},
-    {error, version_not_found} = dmt_client_cache:get_object(?notfound_version, Ref),
-    {error, object_not_found} = dmt_client_cache:get_object(?existing_version, Ref).
+    {error, version_not_found} = dmt_client_cache:get(?notfound_version, Ref),
+    {error, object_not_found} = dmt_client_cache:get(?existing_version, Ref).

--- a/test/dmt_client_cache_SUITE.erl
+++ b/test/dmt_client_cache_SUITE.erl
@@ -114,18 +114,18 @@ pull_range(_Version, _Limit, _Opts) ->
 
 -spec get_snapshot_success(config()) -> any().
 get_snapshot_success(_C) ->
-    {ok, #'Snapshot'{}} = dmt_client_cache:checkout(?existing_version, undefined).
+    {ok, #'Snapshot'{}} = dmt_client_cache:get(?existing_version, undefined).
 
 -spec snapshot_not_found(config()) -> any().
 snapshot_not_found(_C) ->
-    {error, version_not_found} = dmt_client_cache:checkout(?notfound_version, undefined).
+    {error, version_not_found} = dmt_client_cache:get(?notfound_version, undefined).
 
 -spec woody_error(config()) -> any().
 woody_error(_C) ->
-    {error, {woody_error, _}} = dmt_client_cache:checkout(?unavailable_version, undefined).
+    {error, {woody_error, _}} = dmt_client_cache:get(?unavailable_version, undefined).
 
 -spec object_not_found(config()) -> any().
 object_not_found(_C) ->
     Ref = {category, #'domain_CategoryRef'{id = 1}},
-    {error, version_not_found} = dmt_client_cache:checkout_object(?notfound_version, Ref, undefined),
-    {error, object_not_found} = dmt_client_cache:checkout_object(?existing_version, Ref, undefined).
+    {error, version_not_found} = dmt_client_cache:get_object(?notfound_version, Ref, undefined),
+    {error, object_not_found} = dmt_client_cache:get_object(?existing_version, Ref, undefined).

--- a/test/dmt_client_tests_SUITE.erl
+++ b/test/dmt_client_tests_SUITE.erl
@@ -56,14 +56,14 @@ end_per_suite(C) ->
 poll(_C) ->
     Object = fixture_domain_object(1, <<"InsertFixture">>),
     Ref = fixture_object_ref(1),
-    #'ObjectNotFound'{} = (catch dmt_client:get(latest, Ref)),
-    #'Snapshot'{version = Version1} = dmt_client:get_snapshot(latest),
+    #'ObjectNotFound'{} = (catch dmt_client:checkout_object(latest, Ref)),
+    #'Snapshot'{version = Version1} = dmt_client:checkout(latest),
     Version2 = dmt_client_api:commit(Version1, #'Commit'{ops = [{insert, #'InsertOp'{object = Object}}]}, undefined),
     true = Version1 < Version2,
     _ = dmt_client_cache:update(),
-    #'Snapshot'{version = Version2} = dmt_client:get_snapshot(latest),
-    Object = dmt_client:get(latest, Ref),
-    #'VersionedObject'{version = Version2, object = Object} = dmt_client:get_versioned(latest, Ref),
+    #'Snapshot'{version = Version2} = dmt_client:checkout(latest),
+    Object = dmt_client:checkout_object(latest, Ref),
+    #'VersionedObject'{version = Version2, object = Object} = dmt_client:checkout_versioned_object(latest, Ref),
     timer:sleep(5000),
     erlang:display(ets:tab2list(dmt_client_cache_users)).
 

--- a/test/dmt_client_tests_SUITE.erl
+++ b/test/dmt_client_tests_SUITE.erl
@@ -56,13 +56,13 @@ end_per_suite(C) ->
 poll(_C) ->
     Object = fixture_domain_object(1, <<"InsertFixture">>),
     Ref = fixture_object_ref(1),
-    #'ObjectNotFound'{} = (catch dmt_client:checkout_object({head, #'Head'{}}, Ref)),
-    #'Snapshot'{version = Version1} = dmt_client:checkout({head, #'Head'{}}),
+    #'ObjectNotFound'{} = (catch dmt_client:get({head, #'Head'{}}, Ref)),
+    #'Snapshot'{version = Version1} = dmt_client:get_snapshot({head, #'Head'{}}),
     Version2 = dmt_client_api:commit(Version1, #'Commit'{ops = [{insert, #'InsertOp'{object = Object}}]}, undefined),
     true = Version1 < Version2,
     _ = dmt_client_cache:update(),
-    #'Snapshot'{version = Version2} = dmt_client:checkout({head, #'Head'{}}),
-    #'VersionedObject'{object = Object} = dmt_client:checkout_object({head, #'Head'{}}, Ref).
+    #'Snapshot'{version = Version2} = dmt_client:get_snapshot({head, #'Head'{}}),
+    #'VersionedObject'{object = Object} = dmt_client:get({head, #'Head'{}}, Ref).
 
 fixture_domain_object(Ref, Data) ->
     {category, #'domain_CategoryObject'{

--- a/test/dmt_client_tests_SUITE.erl
+++ b/test/dmt_client_tests_SUITE.erl
@@ -63,9 +63,7 @@ poll(_C) ->
     _ = dmt_client_cache:update(),
     #'Snapshot'{version = Version2} = dmt_client:checkout(latest),
     Object = dmt_client:checkout_object(latest, Ref),
-    #'VersionedObject'{version = Version2, object = Object} = dmt_client:checkout_versioned_object(latest, Ref),
-    timer:sleep(5000),
-    erlang:display(ets:tab2list(dmt_client_cache_users)).
+    #'VersionedObject'{version = Version2, object = Object} = dmt_client:checkout_versioned_object(latest, Ref).
 
 fixture_domain_object(Ref, Data) ->
     {category, #'domain_CategoryObject'{

--- a/test/dmt_client_tests_SUITE.erl
+++ b/test/dmt_client_tests_SUITE.erl
@@ -62,7 +62,8 @@ poll(_C) ->
     true = Version1 < Version2,
     _ = dmt_client_cache:update(),
     #'Snapshot'{version = Version2} = dmt_client:get_snapshot(latest),
-    #'VersionedObject'{object = Object} = dmt_client:get(latest, Ref).
+    Object = dmt_client:get(latest, Ref),
+    #'VersionedObject'{version = Version2, object = Object} = dmt_client:get_versioned(latest, Ref).
 
 fixture_domain_object(Ref, Data) ->
     {category, #'domain_CategoryObject'{

--- a/test/dmt_client_tests_SUITE.erl
+++ b/test/dmt_client_tests_SUITE.erl
@@ -63,7 +63,9 @@ poll(_C) ->
     _ = dmt_client_cache:update(),
     #'Snapshot'{version = Version2} = dmt_client:get_snapshot(latest),
     Object = dmt_client:get(latest, Ref),
-    #'VersionedObject'{version = Version2, object = Object} = dmt_client:get_versioned(latest, Ref).
+    #'VersionedObject'{version = Version2, object = Object} = dmt_client:get_versioned(latest, Ref),
+    timer:sleep(5000),
+    erlang:display(ets:tab2list(dmt_client_cache_users)).
 
 fixture_domain_object(Ref, Data) ->
     {category, #'domain_CategoryObject'{

--- a/test/dmt_client_tests_SUITE.erl
+++ b/test/dmt_client_tests_SUITE.erl
@@ -56,13 +56,13 @@ end_per_suite(C) ->
 poll(_C) ->
     Object = fixture_domain_object(1, <<"InsertFixture">>),
     Ref = fixture_object_ref(1),
-    #'ObjectNotFound'{} = (catch dmt_client:get({head, #'Head'{}}, Ref)),
-    #'Snapshot'{version = Version1} = dmt_client:get_snapshot({head, #'Head'{}}),
+    #'ObjectNotFound'{} = (catch dmt_client:get(latest, Ref)),
+    #'Snapshot'{version = Version1} = dmt_client:get_snapshot(latest),
     Version2 = dmt_client_api:commit(Version1, #'Commit'{ops = [{insert, #'InsertOp'{object = Object}}]}, undefined),
     true = Version1 < Version2,
     _ = dmt_client_cache:update(),
-    #'Snapshot'{version = Version2} = dmt_client:get_snapshot({head, #'Head'{}}),
-    #'VersionedObject'{object = Object} = dmt_client:get({head, #'Head'{}}, Ref).
+    #'Snapshot'{version = Version2} = dmt_client:get_snapshot(latest),
+    #'VersionedObject'{object = Object} = dmt_client:get(latest, Ref).
 
 fixture_domain_object(Ref, Data) ->
     {category, #'domain_CategoryObject'{


### PR DESCRIPTION
См. обсуждение проблемы в #44 (ED-180):
- https://github.com/rbkmoney/dmt_client/pull/44#discussion_r654423950
- https://github.com/rbkmoney/dmt_client/pull/44#discussion_r656441609

Прошлая (до #44) и текущая реализация кэша никак не учитывает возможность постоянного соперничества клиентов за ets-кэш со снапшотами ввиду строгих лимитов кэша по элементам и/или памяти.

Данный PR предлагает решение этой проблемы в виде системы локов снапшотов на основе пользователей, запрашивающих конкретный снапшот.

TBD:
- [ ] Тесты 
    - property-based?
    - проверка на корректную конкурентную работу