### PR TITLE
Fix/commit latest

### DIFF
--- a/src/dmt_client.erl
+++ b/src/dmt_client.erl
@@ -193,8 +193,10 @@ commit(Reference, Commit) ->
     commit(Reference, Commit, #{}).
 
 -spec commit(version(), commit(), opts()) -> vsn() | no_return().
-commit(Reference, Commit, Opts) ->
-    Version = ref_to_version(Reference),
+commit(latest, Commit, Opts) ->
+    Version = unwrap(dmt_client_cache:update()),
+    commit(Version, Commit, Opts);
+commit(Version, Commit, Opts) ->
     Result = dmt_client_backend:commit(Version, Commit, Opts),
     _NewVersion = unwrap(dmt_client_cache:update()),
     Result.

--- a/test/dmt_client_tests_SUITE.erl
+++ b/test/dmt_client_tests_SUITE.erl
@@ -63,7 +63,6 @@ insert_and_all_checkouts(_C) ->
     #'Snapshot'{version = Version1} = dmt_client:checkout(),
     Version2 = dmt_client:insert(Object),
     true = Version1 < Version2,
-    _ = dmt_client_cache:update(),
     #'Snapshot'{version = Version2} = dmt_client:checkout(),
     Object = dmt_client:checkout_object(Ref),
     #'VersionedObject'{version = Version2, object = Object} = dmt_client:checkout_versioned_object(latest, Ref).


### PR DESCRIPTION
Понял, что сейчас есть небольшая проблема работы с `commit-подобными` операциями, аргументом в которых фигурирует `latest`: в случае мисматча хэда в кэше и доминанте выбросится ошибка о коммите на устаревшую версию.

Данный PR добавляет апдейт кэша перед коммитом на `latest` версию с целью актуализации хэда в кэше.

Also: по ошибке не было предоставлено `/3` версий новых методов для удобства (с `opts()`). Добавлены. 